### PR TITLE
fix: set deployment.base for /docs mount under mediadrop.dev

### DIFF
--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
 		repo: true,
 	},
 	deployment: {
+		base: "/docs",
 		site: "https://www.mediadrop.dev/docs",
 	},
 	analytics: {

--- a/apps/docs/docs/changelog.mdx
+++ b/apps/docs/docs/changelog.mdx
@@ -5,6 +5,14 @@ sidebar:
 description: Release notes for react-mediadrop
 ---
 
+## 0.1.1
+
+### Patch
+
+- Updated package READMEs (`react-mediadrop`, `@mediadrop/core`,
+  `@mediadrop/xhr-upload`) to match the current docs — install steps,
+  quickstart, entry points.
+
 ## 0.1.0
 
 ### Initial release


### PR DESCRIPTION
## Summary
- Sets `deployment.base: "/docs"` in `apps/docs/blume.config.ts` so Astro emits every asset/nav URL prefixed with `/docs`.

## Why
Vercel proxies `/docs` and `/docs/:match*` to the CF Pages deploy, stripping the `/docs` prefix before forwarding to `pages.dev`. Without `deployment.base`, Astro emitted bare root paths (`/_astro/...`, `/changelog`), which escape the `/docs` segment once resolved against `www.mediadrop.dev` — neither Vercel rewrite rule matches an unprefixed path, so those requests 404 on Vercel's own site instead of reaching CF Pages.

## Test plan
- [x] Clean `pnpm run build` in `apps/docs` — confirmed emitted HTML now links `/docs/_astro/...`, `/docs/changelog`, etc.
- [x] Confirmed `dist/` file layout stays root-relative (unprefixed), matching what the Vercel rewrite's destination expects.
- [ ] Redeploy CF Pages from this branch/merge, verify `www.mediadrop.dev/docs` loads with working assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected documentation site deployment routing by configuring the `/docs` base path.
* **Documentation**
  * Added a changelog entry for version 0.1.1, noting updates to multiple package READMEs to align with current installation and quickstart documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->