### PR TITLE
docs: add Open in StackBlitz to uploads examples

### DIFF
--- a/apps/docs/docs/examples/(basics)/accept.mdx
+++ b/apps/docs/docs/examples/(basics)/accept.mdx
@@ -3,39 +3,15 @@ title: Accepting file types
 description: Restrict the dropzone to specific MIME types with restrictions.accept.
 ---
 
+import acceptCode from "../../../examples-source/accept.tsx?raw";
+
 Restrict the dropzone to specific file types with `restrictions.accept`.
 
 <AcceptExample />
 
-```tsx
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={acceptCode} title="react-mediadrop — Accepting file types" />
 
-export function AcceptExample() {
-  const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
-    useMediaDrop({ restrictions: { accept: ["image/png", "image/jpeg"] } });
-
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-        {rejectedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60">
-            {file.name} — {file.size.toLocaleString()} bytes · {file.errors.map((e) => e.message).join(", ")}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+<CodeBlock code={acceptCode} lang="tsx" />
 
 `accept` takes an exact MIME type (`"image/png"`), a wildcard
 (`"image/*"`), a file extension (`".png"`), or an array/comma-separated

--- a/apps/docs/docs/examples/(basics)/basic.mdx
+++ b/apps/docs/docs/examples/(basics)/basic.mdx
@@ -3,42 +3,12 @@ title: Minimal setup
 description: The minimal setup — file intake and drag state, no validation and no upload transport.
 ---
 
+import basicCode from "../../../examples-source/basic.tsx?raw";
+
 The minimal setup: file intake and drag state, no validation and no upload transport.
 
 <BasicExample />
 
-```tsx
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={basicCode} title="react-mediadrop — Minimal setup" />
 
-export function BasicExample() {
-  const { acceptedFiles, getRootProps, getInputProps, isDragActive } =
-    useMediaDrop();
-
-  return (
-    <div className="space-y-3">
-      <div
-        {...getRootProps()}
-        className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center
-          border-zinc-300 text-zinc-500 dark:border-zinc-700 dark:text-zinc-400
-          ${isDragActive ? "border-sky-500 bg-zinc-100 dark:bg-zinc-900" : ""}`}
-      >
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      {acceptedFiles.length > 0 && (
-        <ul className="space-y-2">
-          {acceptedFiles.map((file) => (
-            <li
-              key={file.id}
-              className="flex items-start gap-2 rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
-            >
-              <span className="truncate">{file.name}</span>
-              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes</span>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
-}
-```
+<CodeBlock code={basicCode} lang="tsx" />

--- a/apps/docs/docs/examples/(basics)/drag-states.mdx
+++ b/apps/docs/docs/examples/(basics)/drag-states.mdx
@@ -3,59 +3,16 @@ title: Drag states
 description: Every drag flag useMediaDrop returns, read live off one dropzone.
 ---
 
+import dragStatesCode from "../../../examples-source/drag-states.tsx?raw";
+
 `useMediaDrop` returns five drag/focus flags. Drag an image over the
 zone below to watch them flip live.
 
 <DragStatesExample />
 
-```tsx
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={dragStatesCode} title="react-mediadrop — Drag states" />
 
-export function DragStatesExample() {
-  const {
-    acceptedFiles,
-    getRootProps,
-    getInputProps,
-    isDragActive,
-    isDragAccept,
-    isDragReject,
-    isFocused,
-    isDragGlobal,
-  } = useMediaDrop({ restrictions: { accept: ["image/*"] } });
-
-  return (
-    <div className="w-full space-y-3">
-      <div
-        {...getRootProps()}
-        className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center
-          border-zinc-300 dark:border-zinc-700
-          ${isDragAccept ? "border-green-500" : ""}
-          ${isDragReject ? "border-red-500" : ""}
-          ${isDragActive && !isDragAccept && !isDragReject ? "border-sky-500" : ""}`}
-      >
-        <input {...getInputProps()} />
-        <p>Drag an image here, or click to browse</p>
-      </div>
-
-      <div className="flex flex-wrap gap-2 text-xs">
-        <span>isDragActive: {String(isDragActive)}</span>
-        <span>isDragAccept: {String(isDragAccept)}</span>
-        <span>isDragReject: {String(isDragReject)}</span>
-        <span>isFocused: {String(isFocused)}</span>
-        <span>isDragGlobal: {String(isDragGlobal)}</span>
-      </div>
-
-      <ul className="m-0 w-full list-none space-y-2 p-0">
-        {acceptedFiles.map((file) => (
-          <li key={file.id}>
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+<CodeBlock code={dragStatesCode} lang="tsx" />
 
 `isDragAccept`/`isDragReject` are best-effort — browsers only expose a
 dragged file's MIME type, not its name, until drop. An extension-based

--- a/apps/docs/docs/examples/(basics)/events.mdx
+++ b/apps/docs/docs/examples/(basics)/events.mdx
@@ -3,6 +3,8 @@ title: Event propagation
 description: Call event.stopPropagation() in your own onDrop to opt out of react-mediadrop's default handling.
 ---
 
+import eventsCode from "../../../examples-source/events.tsx?raw";
+
 Passing your own `onDrop` to `getRootProps()` runs before
 react-mediadrop's own drop handling. Call `event.stopPropagation()`
 inside it and the default handling — adding the dropped files — never
@@ -10,36 +12,9 @@ runs.
 
 <EventsExample />
 
-```tsx
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={eventsCode} title="react-mediadrop — Event propagation" />
 
-export function EventsExample() {
-  const { acceptedFiles, getRootProps, getInputProps } = useMediaDrop();
-
-  return (
-    <div className="space-y-3">
-      <div
-        {...getRootProps({
-          onDrop: (event) => {
-            event.stopPropagation(); // skips react-mediadrop's own drop handling
-          },
-        })}
-        className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
-      >
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+<CodeBlock code={eventsCode} lang="tsx" />
 
 The same applies to `onClick`, `onKeyDown`, `onFocus`, and `onBlur`
 passed to `getRootProps()`, and `onChange`/`onClick` passed to

--- a/apps/docs/docs/examples/(basics)/file-dialog.mdx
+++ b/apps/docs/docs/examples/(basics)/file-dialog.mdx
@@ -3,38 +3,16 @@ title: Opening the file dialog
 description: Open the native file picker from your own button with open().
 ---
 
+import fileDialogCode from "../../../examples-source/file-dialog.tsx?raw";
+
 Open the native file picker from your own button, instead of the
 dropzone's default click-to-open.
 
 <FileDialogExample />
 
-```tsx
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={fileDialogCode} title="react-mediadrop — Opening the file dialog" />
 
-export function FileDialogExample() {
-  const { acceptedFiles, getRootProps, getInputProps, open } = useMediaDrop({
-    noClick: true,
-    noKeyboard: true,
-  });
-
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here — clicking the dropzone itself does nothing</p>
-        <button type="button" onClick={open}>Choose files</button>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+<CodeBlock code={fileDialogCode} lang="tsx" />
 
 `noClick` and `noKeyboard` turn off the dropzone's own click-to-open and
 Space/Enter-to-open behavior, so `open()` is the only way in. Most

--- a/apps/docs/docs/examples/(basics)/forms.mdx
+++ b/apps/docs/docs/examples/(basics)/forms.mdx
@@ -3,46 +3,17 @@ title: Using it inside a form
 description: Mirror accepted files into a hidden input so a native form submission includes them.
 ---
 
+import formsCode from "../../../examples-source/forms.tsx?raw";
+
 `react-mediadrop`'s files live in its own store, not in a native
 `<input type="file">` — a plain form submission won't include them
 unless you mirror them into a hidden input yourself.
 
 <FormsExample />
 
-```tsx
-import { useMediaDrop } from "react-mediadrop";
-import { useEffect, useRef } from "react";
+<ExampleCodeHeader code={formsCode} title="react-mediadrop — Using it inside a form" />
 
-export function FormsExample() {
-  const { acceptedFiles, getRootProps, getInputProps } = useMediaDrop();
-  const hiddenInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    if (!hiddenInputRef.current) return;
-    const dataTransfer = new DataTransfer();
-    for (const item of acceptedFiles) dataTransfer.items.add(item.file);
-    hiddenInputRef.current.files = dataTransfer.files;
-  }, [acceptedFiles]);
-
-  return (
-    <form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <input ref={hiddenInputRef} type="file" name="attachments" multiple className="hidden" />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-      </ul>
-      <button type="submit">Submit</button>
-    </form>
-  );
-}
-```
+<CodeBlock code={formsCode} lang="tsx" />
 
 Each `MediaDropFile` carries the original browser `File` on `.file` —
 that's what gets added to the hidden input's `DataTransfer`. On submit,

--- a/apps/docs/docs/examples/(basics)/max-files.mdx
+++ b/apps/docs/docs/examples/(basics)/max-files.mdx
@@ -3,39 +3,15 @@ title: Max files
 description: Cap how many files a dropzone accepts with restrictions.maxFiles.
 ---
 
+import maxFilesCode from "../../../examples-source/max-files.tsx?raw";
+
 Cap how many files a dropzone accepts with `restrictions.maxFiles`.
 
 <MaxFilesExample />
 
-```tsx
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={maxFilesCode} title="react-mediadrop — Max files" />
 
-export function MaxFilesExample() {
-  const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
-    useMediaDrop({ restrictions: { maxFiles: 3 } });
-
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-        {rejectedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60">
-            {file.name} — {file.size.toLocaleString()} bytes · {file.errors[0]?.message}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+<CodeBlock code={maxFilesCode} lang="tsx" />
 
 `maxFiles` is evaluated across the whole file list, not per file. Drop a
 batch bigger than the remaining slots and files fill the remaining slots

--- a/apps/docs/docs/examples/(basics)/styling.mdx
+++ b/apps/docs/docs/examples/(basics)/styling.mdx
@@ -3,61 +3,17 @@ title: Styling
 description: getRootProps() sets no className or style of its own — you're in full control.
 ---
 
+import stylingCode from "../../../examples-source/styling.tsx?raw";
+
 `getRootProps()`/`getInputProps()` set no `className` or `style` of
 their own — you're in full control, and anything you pass through is
 merged in.
 
 <StylingExample />
 
-```tsx
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={stylingCode} title="react-mediadrop — Styling" />
 
-export function StylingExample() {
-  const {
-    acceptedFiles,
-    getRootProps,
-    getInputProps,
-    isFocused,
-    isDragActive,
-    isDragAccept,
-    isDragReject,
-  } = useMediaDrop({ restrictions: { accept: ["image/*"] } });
-
-  const border =
-    isDragAccept ? "border-green-500"
-    : isDragReject ? "border-red-500"
-    : isDragActive ? "border-sky-500"
-    : isFocused ? "border-sky-600"
-    : "border-zinc-300 dark:border-zinc-700";
-
-  return (
-    <div className="w-full space-y-3">
-      <div
-        {...getRootProps()}
-        className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center ${border}`}
-      >
-        <input {...getInputProps()} />
-        <p>Drag an image here, or click to browse</p>
-      </div>
-
-      <div className="flex flex-wrap gap-2 text-xs">
-        <span>isFocused: {String(isFocused)}</span>
-        <span>isDragActive: {String(isDragActive)}</span>
-        <span>isDragAccept: {String(isDragAccept)}</span>
-        <span>isDragReject: {String(isDragReject)}</span>
-      </div>
-
-      <ul className="m-0 w-full list-none space-y-2 p-0">
-        {acceptedFiles.map((file) => (
-          <li key={file.id}>
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+<CodeBlock code={stylingCode} lang="tsx" />
 
 A `style`/`className` you pass to `getRootProps()` or `getInputProps()`
 is merged with what the hook needs internally — the one exception is

--- a/apps/docs/docs/examples/(basics)/validator.mdx
+++ b/apps/docs/docs/examples/(basics)/validator.mdx
@@ -3,47 +3,16 @@ title: Custom validation
 description: Reject files with a validator function react-mediadrop can't express through restrictions.
 ---
 
+import validatorCode from "../../../examples-source/validator.tsx?raw";
+
 Reject files with a `validator` function for rules `restrictions` can't
 express.
 
 <ValidatorExample />
 
-```tsx
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={validatorCode} title="react-mediadrop — Custom validation" />
 
-function noSpacesValidator(file: File) {
-  if (file.name.includes(" ")) {
-    return { code: "validator-error" as const, message: "Filenames can't contain spaces" };
-  }
-  return null;
-}
-
-export function ValidatorExample() {
-  const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
-    useMediaDrop({ validator: noSpacesValidator });
-
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-        {rejectedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60">
-            {file.name} — {file.size.toLocaleString()} bytes · {file.errors?.[0]?.message}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+<CodeBlock code={validatorCode} lang="tsx" />
 
 Return `null`/`undefined` to accept, or one error / an array of errors to
 reject. Don't reimplement `accept`/`maxSize`/`minSize` here — use

--- a/apps/docs/docs/examples/(uploads)/cancel-retry.mdx
+++ b/apps/docs/docs/examples/(uploads)/cancel-retry.mdx
@@ -3,6 +3,8 @@ title: Cancel and retry
 description: Cancel an in-flight upload with cancelUpload(), and recover from a failed one with retryUpload().
 ---
 
+import cancelRetryCode from "../../../examples-source/cancel-retry.tsx?raw";
+
 `cancelUpload(id)` aborts an in-flight upload via `AbortSignal` and ends
 in `uploadStatus: "canceled"`. `retryUpload(id)` re-enqueues a file, but
 only once its last attempt ended in `uploadStatus: "error"`.
@@ -17,53 +19,9 @@ failure to retry. The API below is real — see
 for the full `cancelUpload`/`retryUpload` contract.
 :::
 
-```tsx
-import { useEffect } from "react";
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={cancelRetryCode} title="react-mediadrop — Cancel and retry" />
 
-export function CancelRetryExample({ transport }: { transport: UploadTransport }) {
-  const { files, getRootProps, getInputProps, uploadFile, cancelUpload, retryUpload } =
-    useMediaDrop({ transport });
-
-  useEffect(() => {
-    for (const file of files) {
-      if (file.status === "accepted" && file.uploadStatus === undefined) {
-        uploadFile(file.id);
-      }
-    }
-  }, [files, uploadFile]);
-
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {files.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            <div className="flex items-center justify-between gap-2">
-              <span className="truncate">{file.name}</span>
-              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes · {file.uploadStatus ?? file.status}</span>
-              {(file.uploadStatus === "queued" || file.uploadStatus === "uploading") && (
-                <button aria-label="Cancel" onClick={() => cancelUpload(file.id)}>✕</button>
-              )}
-              {file.uploadStatus === "error" && (
-                <button aria-label="Retry" onClick={() => retryUpload(file.id)}>↻</button>
-              )}
-            </div>
-            <progress
-              className="mt-2 h-1.5 w-full"
-              value={file.progress?.loaded ?? 0}
-              max={file.progress?.total ?? file.size}
-            />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+<CodeBlock code={cancelRetryCode} lang="tsx" />
 
 Retrying stops immediately once a file is canceled — a cancel always
 wins over a pending retry. This manual `retryUpload` is separate from

--- a/apps/docs/docs/examples/(uploads)/concurrency.mdx
+++ b/apps/docs/docs/examples/(uploads)/concurrency.mdx
@@ -3,6 +3,8 @@ title: Concurrency limit
 description: Cap how many uploads run at once with the concurrency option — the rest wait as "queued".
 ---
 
+import concurrencyCode from "../../../examples-source/concurrency.tsx?raw";
+
 Pass `concurrency` to `useMediaDrop({ transport, concurrency })` to cap
 how many uploads run at once. Every file beyond that cap sits at
 `uploadStatus: "queued"` until a slot frees up.
@@ -16,49 +18,9 @@ below is real — see
 [Upload](/guides/upload#how-do-i-configure-concurrency-retry-and-cancel).
 :::
 
-```tsx
-import { useEffect } from "react";
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={concurrencyCode} title="react-mediadrop — Concurrency limit" />
 
-export function ConcurrencyExample({ transport }: { transport: UploadTransport }) {
-  const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({
-    transport,
-    concurrency: 2, // at most 2 uploads in flight at once. Default 1.
-  });
-
-  useEffect(() => {
-    for (const file of files) {
-      if (file.status === "accepted" && file.uploadStatus === undefined) {
-        uploadFile(file.id);
-      }
-    }
-  }, [files, uploadFile]);
-
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drop several files at once</p>
-      </div>
-      <ul className="space-y-2">
-        {files.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            <div className="flex justify-between">
-              <span>{file.name}</span>
-              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes · {file.uploadStatus ?? file.status}</span>
-            </div>
-            <progress
-              className="mt-2 h-1.5 w-full"
-              value={file.progress?.loaded ?? 0}
-              max={file.progress?.total ?? file.size}
-            />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+<CodeBlock code={concurrencyCode} lang="tsx" />
 
 Drop more files than the `concurrency` cap and only that many ever show
 `"uploading"` at once — the rest hold at `"queued"` until a slot frees

--- a/apps/docs/docs/examples/(uploads)/presigned-url.mdx
+++ b/apps/docs/docs/examples/(uploads)/presigned-url.mdx
@@ -3,6 +3,8 @@ title: Presigned URL upload
 description: Upload directly to a presigned PUT URL (S3, GCS, or any provider) by resolving the URL before the upload starts.
 ---
 
+import presignedUrlCode from "../../../examples-source/presigned-url.tsx?raw";
+
 `createXhrUploadTransport`'s `endpoint` can be a function of the file, but
 it's synchronous &mdash; it can't `await` a request to your server. Resolve
 each file's presigned URL first, then call `uploadFile(id)` once you have it.
@@ -16,44 +18,9 @@ provider-agnostic: it works the same for S3, GCS, or Azure SAS URLs, or any
 endpoint your own server signs.
 :::
 
-```tsx
-import { useEffect, useRef, useState } from "react";
-import { useMediaDrop } from "react-mediadrop";
-import { createXhrUploadTransport } from "react-mediadrop/xhr-upload";
+<ExampleCodeHeader code={presignedUrlCode} title="react-mediadrop — Presigned URL upload" />
 
-export function PresignedUploadExample() {
-  const [urls, setUrls] = useState<Record<string, string>>({});
-  const requested = useRef(new Set<string>());
-
-  const transport = createXhrUploadTransport({
-    formData: false, // send the raw file body, not multipart/form-data
-    endpoint: (file) => urls[file.id],
-  });
-
-  const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({ transport });
-
-  useEffect(() => {
-    for (const file of files) {
-      if (file.status === "accepted" && file.uploadStatus === undefined && !requested.current.has(file.id)) {
-        requested.current.add(file.id);
-        fetch(`/api/presign?filename=${file.name}`)
-          .then((response) => response.json())
-          .then(({ url }) => {
-            setUrls((previous) => ({ ...previous, [file.id]: url }));
-            uploadFile(file.id);
-          });
-      }
-    }
-  }, [files, uploadFile]);
-
-  return (
-    <div {...getRootProps()}>
-      <input {...getInputProps()} />
-      {/* render files, using file.uploadStatus */}
-    </div>
-  );
-}
-```
+<CodeBlock code={presignedUrlCode} lang="tsx" />
 
 `formData: false` sends the file's raw bytes as the request body &mdash; a
 single PUT/POST, not a multipart upload (multiple parts, an upload ID, a

--- a/apps/docs/docs/examples/(uploads)/upload-progress.mdx
+++ b/apps/docs/docs/examples/(uploads)/upload-progress.mdx
@@ -3,6 +3,8 @@ title: Upload progress
 description: Auto-upload accepted files and track per-file progress and status against a transport.
 ---
 
+import uploadProgressCode from "../../../examples-source/upload-progress.tsx?raw";
+
 Call `uploadFile(id)` as soon as a file is accepted, then read
 `progress` and `uploadStatus` off each `MediaDropFile` to render a bar.
 
@@ -17,46 +19,9 @@ docs site. The API below is real: swap in
 else changes.
 :::
 
-```tsx
-import { useEffect } from "react";
-import { useMediaDrop } from "react-mediadrop";
+<ExampleCodeHeader code={uploadProgressCode} title="react-mediadrop — Upload progress" />
 
-export function UploadProgressExample({ transport }: { transport: UploadTransport }) {
-  const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({ transport });
-
-  useEffect(() => {
-    for (const file of files) {
-      if (file.status === "accepted" && file.uploadStatus === undefined) {
-        uploadFile(file.id);
-      }
-    }
-  }, [files, uploadFile]);
-
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {files.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            <div className="flex justify-between">
-              <span>{file.name}</span>
-              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes · {file.uploadStatus ?? file.status}</span>
-            </div>
-            <progress
-              className="mt-2 h-1.5 w-full"
-              value={file.progress?.loaded ?? 0}
-              max={file.progress?.total ?? file.size}
-            />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-```
+<CodeBlock code={uploadProgressCode} lang="tsx" />
 
 `progress` may be `undefined` before upload begins, and `total` may be
 `null` until the transport reports it. Fall back to the file's own

--- a/apps/docs/examples-source/accept.tsx
+++ b/apps/docs/examples-source/accept.tsx
@@ -1,27 +1,37 @@
 import { useMediaDrop } from "react-mediadrop";
 
 export function AcceptExample() {
-  const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
-    useMediaDrop({ restrictions: { accept: ["image/png", "image/jpeg"] } });
+	const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
+		useMediaDrop({ restrictions: { accept: ["image/png", "image/jpeg"] } });
 
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-        {rejectedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60">
-            {file.name} — {file.size.toLocaleString()} bytes · {file.errors.map((e) => e.message).join(", ")}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+	return (
+		<div className="space-y-3">
+			<div
+				{...getRootProps()}
+				className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+			>
+				<input {...getInputProps()} />
+				<p>Drag files here, or click to browse</p>
+			</div>
+			<ul className="space-y-2">
+				{acceptedFiles.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+					>
+						{file.name} — {file.size.toLocaleString()} bytes
+					</li>
+				))}
+				{rejectedFiles.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60"
+					>
+						{file.name} — {file.size.toLocaleString()} bytes ·{" "}
+						{file.errors.map((e) => e.message).join(", ")}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/accept.tsx
+++ b/apps/docs/examples-source/accept.tsx
@@ -1,0 +1,27 @@
+import { useMediaDrop } from "react-mediadrop";
+
+export function AcceptExample() {
+  const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
+    useMediaDrop({ restrictions: { accept: ["image/png", "image/jpeg"] } });
+
+  return (
+    <div className="space-y-3">
+      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
+        <input {...getInputProps()} />
+        <p>Drag files here, or click to browse</p>
+      </div>
+      <ul className="space-y-2">
+        {acceptedFiles.map((file) => (
+          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
+            {file.name} — {file.size.toLocaleString()} bytes
+          </li>
+        ))}
+        {rejectedFiles.map((file) => (
+          <li key={file.id} className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60">
+            {file.name} — {file.size.toLocaleString()} bytes · {file.errors.map((e) => e.message).join(", ")}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/examples-source/basic.tsx
+++ b/apps/docs/examples-source/basic.tsx
@@ -1,0 +1,33 @@
+import { useMediaDrop } from "react-mediadrop";
+
+export function BasicExample() {
+  const { acceptedFiles, getRootProps, getInputProps, isDragActive } =
+    useMediaDrop();
+
+  return (
+    <div className="space-y-3">
+      <div
+        {...getRootProps()}
+        className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center
+          border-zinc-300 text-zinc-500 dark:border-zinc-700 dark:text-zinc-400
+          ${isDragActive ? "border-sky-500 bg-zinc-100 dark:bg-zinc-900" : ""}`}
+      >
+        <input {...getInputProps()} />
+        <p>Drag files here, or click to browse</p>
+      </div>
+      {acceptedFiles.length > 0 && (
+        <ul className="space-y-2">
+          {acceptedFiles.map((file) => (
+            <li
+              key={file.id}
+              className="flex items-start gap-2 rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+            >
+              <span className="truncate">{file.name}</span>
+              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/docs/examples-source/basic.tsx
+++ b/apps/docs/examples-source/basic.tsx
@@ -1,33 +1,35 @@
 import { useMediaDrop } from "react-mediadrop";
 
 export function BasicExample() {
-  const { acceptedFiles, getRootProps, getInputProps, isDragActive } =
-    useMediaDrop();
+	const { acceptedFiles, getRootProps, getInputProps, isDragActive } =
+		useMediaDrop();
 
-  return (
-    <div className="space-y-3">
-      <div
-        {...getRootProps()}
-        className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center
+	return (
+		<div className="space-y-3">
+			<div
+				{...getRootProps()}
+				className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center
           border-zinc-300 text-zinc-500 dark:border-zinc-700 dark:text-zinc-400
           ${isDragActive ? "border-sky-500 bg-zinc-100 dark:bg-zinc-900" : ""}`}
-      >
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      {acceptedFiles.length > 0 && (
-        <ul className="space-y-2">
-          {acceptedFiles.map((file) => (
-            <li
-              key={file.id}
-              className="flex items-start gap-2 rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
-            >
-              <span className="truncate">{file.name}</span>
-              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes</span>
-            </li>
-          ))}
-        </ul>
-      )}
-    </div>
-  );
+			>
+				<input {...getInputProps()} />
+				<p>Drag files here, or click to browse</p>
+			</div>
+			{acceptedFiles.length > 0 && (
+				<ul className="space-y-2">
+					{acceptedFiles.map((file) => (
+						<li
+							key={file.id}
+							className="flex items-start gap-2 rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+						>
+							<span className="truncate">{file.name}</span>
+							<span className="text-xs text-zinc-500">
+								{file.size.toLocaleString()} bytes
+							</span>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
 }

--- a/apps/docs/examples-source/cancel-retry.tsx
+++ b/apps/docs/examples-source/cancel-retry.tsx
@@ -1,0 +1,81 @@
+import { useEffect } from "react";
+import { createHttpError, useMediaDrop, type UploadTransport } from "react-mediadrop";
+
+const failedOnce = new Set<string>();
+
+const transport: UploadTransport = {
+  upload(file, { onProgress, signal }) {
+    return new Promise((resolve, reject) => {
+      const total = file.size;
+      const durationMs = 4000;
+      const start = performance.now();
+
+      const onAbort = () => {
+        clearInterval(interval);
+        reject(createHttpError("Aborted"));
+      };
+
+      const interval = setInterval(() => {
+        const elapsed = performance.now() - start;
+        const loaded = Math.min(total, Math.round((elapsed / durationMs) * total));
+        onProgress({ loaded, total });
+
+        if (elapsed >= durationMs) {
+          clearInterval(interval);
+          signal.removeEventListener("abort", onAbort);
+          if (!failedOnce.has(file.id)) {
+            failedOnce.add(file.id);
+            reject(createHttpError("Simulated upload failure", 500));
+          } else {
+            resolve({ response: { simulated: true } });
+          }
+        }
+      }, 100);
+
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  },
+};
+
+export function CancelRetryExample() {
+  const { files, getRootProps, getInputProps, uploadFile, cancelUpload, retryUpload } =
+    useMediaDrop({ transport });
+
+  useEffect(() => {
+    for (const file of files) {
+      if (file.status === "accepted" && file.uploadStatus === undefined) {
+        uploadFile(file.id);
+      }
+    }
+  }, [files, uploadFile]);
+
+  return (
+    <div className="space-y-3">
+      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
+        <input {...getInputProps()} />
+        <p>Drag files here, or click to browse</p>
+      </div>
+      <ul className="space-y-2">
+        {files.map((file) => (
+          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate">{file.name}</span>
+              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes · {file.uploadStatus ?? file.status}</span>
+              {(file.uploadStatus === "queued" || file.uploadStatus === "uploading") && (
+                <button aria-label="Cancel" onClick={() => cancelUpload(file.id)}>✕</button>
+              )}
+              {file.uploadStatus === "error" && (
+                <button aria-label="Retry" onClick={() => retryUpload(file.id)}>↻</button>
+              )}
+            </div>
+            <progress
+              className="mt-2 h-1.5 w-full"
+              value={file.progress?.loaded ?? 0}
+              max={file.progress?.total ?? file.size}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/examples-source/cancel-retry.tsx
+++ b/apps/docs/examples-source/cancel-retry.tsx
@@ -1,81 +1,116 @@
 import { useEffect } from "react";
-import { createHttpError, useMediaDrop, type UploadTransport } from "react-mediadrop";
+import {
+	createHttpError,
+	type UploadTransport,
+	useMediaDrop,
+} from "react-mediadrop";
 
 const failedOnce = new Set<string>();
 
 const transport: UploadTransport = {
-  upload(file, { onProgress, signal }) {
-    return new Promise((resolve, reject) => {
-      const total = file.size;
-      const durationMs = 4000;
-      const start = performance.now();
+	upload(file, { onProgress, signal }) {
+		return new Promise((resolve, reject) => {
+			const total = file.size;
+			const durationMs = 4000;
+			const start = performance.now();
 
-      const onAbort = () => {
-        clearInterval(interval);
-        reject(createHttpError("Aborted"));
-      };
+			const onAbort = () => {
+				clearInterval(interval);
+				reject(createHttpError("Aborted"));
+			};
 
-      const interval = setInterval(() => {
-        const elapsed = performance.now() - start;
-        const loaded = Math.min(total, Math.round((elapsed / durationMs) * total));
-        onProgress({ loaded, total });
+			const interval = setInterval(() => {
+				const elapsed = performance.now() - start;
+				const loaded = Math.min(
+					total,
+					Math.round((elapsed / durationMs) * total),
+				);
+				onProgress({ loaded, total });
 
-        if (elapsed >= durationMs) {
-          clearInterval(interval);
-          signal.removeEventListener("abort", onAbort);
-          if (!failedOnce.has(file.id)) {
-            failedOnce.add(file.id);
-            reject(createHttpError("Simulated upload failure", 500));
-          } else {
-            resolve({ response: { simulated: true } });
-          }
-        }
-      }, 100);
+				if (elapsed >= durationMs) {
+					clearInterval(interval);
+					signal.removeEventListener("abort", onAbort);
+					if (!failedOnce.has(file.id)) {
+						failedOnce.add(file.id);
+						reject(createHttpError("Simulated upload failure", 500));
+					} else {
+						resolve({ response: { simulated: true } });
+					}
+				}
+			}, 100);
 
-      signal.addEventListener("abort", onAbort, { once: true });
-    });
-  },
+			signal.addEventListener("abort", onAbort, { once: true });
+		});
+	},
 };
 
 export function CancelRetryExample() {
-  const { files, getRootProps, getInputProps, uploadFile, cancelUpload, retryUpload } =
-    useMediaDrop({ transport });
+	const {
+		files,
+		getRootProps,
+		getInputProps,
+		uploadFile,
+		cancelUpload,
+		retryUpload,
+	} = useMediaDrop({ transport });
 
-  useEffect(() => {
-    for (const file of files) {
-      if (file.status === "accepted" && file.uploadStatus === undefined) {
-        uploadFile(file.id);
-      }
-    }
-  }, [files, uploadFile]);
+	useEffect(() => {
+		for (const file of files) {
+			if (file.status === "accepted" && file.uploadStatus === undefined) {
+				uploadFile(file.id);
+			}
+		}
+	}, [files, uploadFile]);
 
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {files.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            <div className="flex items-center justify-between gap-2">
-              <span className="truncate">{file.name}</span>
-              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes · {file.uploadStatus ?? file.status}</span>
-              {(file.uploadStatus === "queued" || file.uploadStatus === "uploading") && (
-                <button aria-label="Cancel" onClick={() => cancelUpload(file.id)}>✕</button>
-              )}
-              {file.uploadStatus === "error" && (
-                <button aria-label="Retry" onClick={() => retryUpload(file.id)}>↻</button>
-              )}
-            </div>
-            <progress
-              className="mt-2 h-1.5 w-full"
-              value={file.progress?.loaded ?? 0}
-              max={file.progress?.total ?? file.size}
-            />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+	return (
+		<div className="space-y-3">
+			<div
+				{...getRootProps()}
+				className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+			>
+				<input {...getInputProps()} />
+				<p>Drag files here, or click to browse</p>
+			</div>
+			<ul className="space-y-2">
+				{files.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+					>
+						<div className="flex items-center justify-between gap-2">
+							<span className="truncate">{file.name}</span>
+							<span className="text-xs text-zinc-500">
+								{file.size.toLocaleString()} bytes ·{" "}
+								{file.uploadStatus ?? file.status}
+							</span>
+							{(file.uploadStatus === "queued" ||
+								file.uploadStatus === "uploading") && (
+								<button
+									type="button"
+									aria-label="Cancel"
+									onClick={() => cancelUpload(file.id)}
+								>
+									✕
+								</button>
+							)}
+							{file.uploadStatus === "error" && (
+								<button
+									type="button"
+									aria-label="Retry"
+									onClick={() => retryUpload(file.id)}
+								>
+									↻
+								</button>
+							)}
+						</div>
+						<progress
+							className="mt-2 h-1.5 w-full"
+							value={file.progress?.loaded ?? 0}
+							max={file.progress?.total ?? file.size}
+						/>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/concurrency.tsx
+++ b/apps/docs/examples-source/concurrency.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from "react";
+import { createHttpError, useMediaDrop, type UploadTransport } from "react-mediadrop";
+
+const transport: UploadTransport = {
+  upload(file, { onProgress, signal }) {
+    return new Promise((resolve, reject) => {
+      const total = file.size;
+      const durationMs = 2000;
+      const start = performance.now();
+
+      const onAbort = () => {
+        clearInterval(interval);
+        reject(createHttpError("Aborted"));
+      };
+
+      const interval = setInterval(() => {
+        const elapsed = performance.now() - start;
+        const loaded = Math.min(total, Math.round((elapsed / durationMs) * total));
+        onProgress({ loaded, total });
+
+        if (elapsed >= durationMs) {
+          clearInterval(interval);
+          signal.removeEventListener("abort", onAbort);
+          resolve({ response: { simulated: true } });
+        }
+      }, 100);
+
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  },
+};
+
+export function ConcurrencyExample() {
+  const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({
+    transport,
+    concurrency: 2,
+  });
+
+  useEffect(() => {
+    for (const file of files) {
+      if (file.status === "accepted" && file.uploadStatus === undefined) {
+        uploadFile(file.id);
+      }
+    }
+  }, [files, uploadFile]);
+
+  return (
+    <div className="space-y-3">
+      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
+        <input {...getInputProps()} />
+        <p>Drop several files at once</p>
+      </div>
+      <ul className="space-y-2">
+        {files.map((file) => (
+          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate">{file.name}</span>
+              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes · {file.uploadStatus ?? file.status}</span>
+            </div>
+            <progress
+              className="mt-2 h-1.5 w-full"
+              value={file.progress?.loaded ?? 0}
+              max={file.progress?.total ?? file.size}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/examples-source/concurrency.tsx
+++ b/apps/docs/examples-source/concurrency.tsx
@@ -1,70 +1,86 @@
 import { useEffect } from "react";
-import { createHttpError, useMediaDrop, type UploadTransport } from "react-mediadrop";
+import {
+	createHttpError,
+	type UploadTransport,
+	useMediaDrop,
+} from "react-mediadrop";
 
 const transport: UploadTransport = {
-  upload(file, { onProgress, signal }) {
-    return new Promise((resolve, reject) => {
-      const total = file.size;
-      const durationMs = 2000;
-      const start = performance.now();
+	upload(file, { onProgress, signal }) {
+		return new Promise((resolve, reject) => {
+			const total = file.size;
+			const durationMs = 2000;
+			const start = performance.now();
 
-      const onAbort = () => {
-        clearInterval(interval);
-        reject(createHttpError("Aborted"));
-      };
+			const onAbort = () => {
+				clearInterval(interval);
+				reject(createHttpError("Aborted"));
+			};
 
-      const interval = setInterval(() => {
-        const elapsed = performance.now() - start;
-        const loaded = Math.min(total, Math.round((elapsed / durationMs) * total));
-        onProgress({ loaded, total });
+			const interval = setInterval(() => {
+				const elapsed = performance.now() - start;
+				const loaded = Math.min(
+					total,
+					Math.round((elapsed / durationMs) * total),
+				);
+				onProgress({ loaded, total });
 
-        if (elapsed >= durationMs) {
-          clearInterval(interval);
-          signal.removeEventListener("abort", onAbort);
-          resolve({ response: { simulated: true } });
-        }
-      }, 100);
+				if (elapsed >= durationMs) {
+					clearInterval(interval);
+					signal.removeEventListener("abort", onAbort);
+					resolve({ response: { simulated: true } });
+				}
+			}, 100);
 
-      signal.addEventListener("abort", onAbort, { once: true });
-    });
-  },
+			signal.addEventListener("abort", onAbort, { once: true });
+		});
+	},
 };
 
 export function ConcurrencyExample() {
-  const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({
-    transport,
-    concurrency: 2,
-  });
+	const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({
+		transport,
+		concurrency: 2,
+	});
 
-  useEffect(() => {
-    for (const file of files) {
-      if (file.status === "accepted" && file.uploadStatus === undefined) {
-        uploadFile(file.id);
-      }
-    }
-  }, [files, uploadFile]);
+	useEffect(() => {
+		for (const file of files) {
+			if (file.status === "accepted" && file.uploadStatus === undefined) {
+				uploadFile(file.id);
+			}
+		}
+	}, [files, uploadFile]);
 
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drop several files at once</p>
-      </div>
-      <ul className="space-y-2">
-        {files.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            <div className="flex items-center justify-between gap-2">
-              <span className="truncate">{file.name}</span>
-              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes · {file.uploadStatus ?? file.status}</span>
-            </div>
-            <progress
-              className="mt-2 h-1.5 w-full"
-              value={file.progress?.loaded ?? 0}
-              max={file.progress?.total ?? file.size}
-            />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+	return (
+		<div className="space-y-3">
+			<div
+				{...getRootProps()}
+				className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+			>
+				<input {...getInputProps()} />
+				<p>Drop several files at once</p>
+			</div>
+			<ul className="space-y-2">
+				{files.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+					>
+						<div className="flex items-center justify-between gap-2">
+							<span className="truncate">{file.name}</span>
+							<span className="text-xs text-zinc-500">
+								{file.size.toLocaleString()} bytes ·{" "}
+								{file.uploadStatus ?? file.status}
+							</span>
+						</div>
+						<progress
+							className="mt-2 h-1.5 w-full"
+							value={file.progress?.loaded ?? 0}
+							max={file.progress?.total ?? file.size}
+						/>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/drag-states.tsx
+++ b/apps/docs/examples-source/drag-states.tsx
@@ -1,0 +1,46 @@
+import { useMediaDrop } from "react-mediadrop";
+
+export function DragStatesExample() {
+  const {
+    acceptedFiles,
+    getRootProps,
+    getInputProps,
+    isDragActive,
+    isDragAccept,
+    isDragReject,
+    isFocused,
+    isDragGlobal,
+  } = useMediaDrop({ restrictions: { accept: ["image/*"] } });
+
+  return (
+    <div className="w-full space-y-3">
+      <div
+        {...getRootProps()}
+        className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center
+          border-zinc-300 dark:border-zinc-700
+          ${isDragAccept ? "border-green-500" : ""}
+          ${isDragReject ? "border-red-500" : ""}
+          ${isDragActive && !isDragAccept && !isDragReject ? "border-sky-500" : ""}`}
+      >
+        <input {...getInputProps()} />
+        <p>Drag an image here, or click to browse</p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-xs">
+        <span>isDragActive: {String(isDragActive)}</span>
+        <span>isDragAccept: {String(isDragAccept)}</span>
+        <span>isDragReject: {String(isDragReject)}</span>
+        <span>isFocused: {String(isFocused)}</span>
+        <span>isDragGlobal: {String(isDragGlobal)}</span>
+      </div>
+
+      <ul className="m-0 w-full list-none space-y-2 p-0">
+        {acceptedFiles.map((file) => (
+          <li key={file.id}>
+            {file.name} — {file.size.toLocaleString()} bytes
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/examples-source/drag-states.tsx
+++ b/apps/docs/examples-source/drag-states.tsx
@@ -1,46 +1,46 @@
 import { useMediaDrop } from "react-mediadrop";
 
 export function DragStatesExample() {
-  const {
-    acceptedFiles,
-    getRootProps,
-    getInputProps,
-    isDragActive,
-    isDragAccept,
-    isDragReject,
-    isFocused,
-    isDragGlobal,
-  } = useMediaDrop({ restrictions: { accept: ["image/*"] } });
+	const {
+		acceptedFiles,
+		getRootProps,
+		getInputProps,
+		isDragActive,
+		isDragAccept,
+		isDragReject,
+		isFocused,
+		isDragGlobal,
+	} = useMediaDrop({ restrictions: { accept: ["image/*"] } });
 
-  return (
-    <div className="w-full space-y-3">
-      <div
-        {...getRootProps()}
-        className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center
+	return (
+		<div className="w-full space-y-3">
+			<div
+				{...getRootProps()}
+				className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center
           border-zinc-300 dark:border-zinc-700
           ${isDragAccept ? "border-green-500" : ""}
           ${isDragReject ? "border-red-500" : ""}
           ${isDragActive && !isDragAccept && !isDragReject ? "border-sky-500" : ""}`}
-      >
-        <input {...getInputProps()} />
-        <p>Drag an image here, or click to browse</p>
-      </div>
+			>
+				<input {...getInputProps()} />
+				<p>Drag an image here, or click to browse</p>
+			</div>
 
-      <div className="flex flex-wrap gap-2 text-xs">
-        <span>isDragActive: {String(isDragActive)}</span>
-        <span>isDragAccept: {String(isDragAccept)}</span>
-        <span>isDragReject: {String(isDragReject)}</span>
-        <span>isFocused: {String(isFocused)}</span>
-        <span>isDragGlobal: {String(isDragGlobal)}</span>
-      </div>
+			<div className="flex flex-wrap gap-2 text-xs">
+				<span>isDragActive: {String(isDragActive)}</span>
+				<span>isDragAccept: {String(isDragAccept)}</span>
+				<span>isDragReject: {String(isDragReject)}</span>
+				<span>isFocused: {String(isFocused)}</span>
+				<span>isDragGlobal: {String(isDragGlobal)}</span>
+			</div>
 
-      <ul className="m-0 w-full list-none space-y-2 p-0">
-        {acceptedFiles.map((file) => (
-          <li key={file.id}>
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+			<ul className="m-0 w-full list-none space-y-2 p-0">
+				{acceptedFiles.map((file) => (
+					<li key={file.id}>
+						{file.name} — {file.size.toLocaleString()} bytes
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/events.tsx
+++ b/apps/docs/examples-source/events.tsx
@@ -1,28 +1,31 @@
 import { useMediaDrop } from "react-mediadrop";
 
 export function EventsExample() {
-  const { acceptedFiles, getRootProps, getInputProps } = useMediaDrop();
+	const { acceptedFiles, getRootProps, getInputProps } = useMediaDrop();
 
-  return (
-    <div className="space-y-3">
-      <div
-        {...getRootProps({
-          onDrop: (event) => {
-            event.stopPropagation(); // skips react-mediadrop's own drop handling
-          },
-        })}
-        className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
-      >
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+	return (
+		<div className="space-y-3">
+			<div
+				{...getRootProps({
+					onDrop: (event) => {
+						event.stopPropagation(); // skips react-mediadrop's own drop handling
+					},
+				})}
+				className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+			>
+				<input {...getInputProps()} />
+				<p>Drag files here, or click to browse</p>
+			</div>
+			<ul className="space-y-2">
+				{acceptedFiles.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+					>
+						{file.name} — {file.size.toLocaleString()} bytes
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/events.tsx
+++ b/apps/docs/examples-source/events.tsx
@@ -1,0 +1,28 @@
+import { useMediaDrop } from "react-mediadrop";
+
+export function EventsExample() {
+  const { acceptedFiles, getRootProps, getInputProps } = useMediaDrop();
+
+  return (
+    <div className="space-y-3">
+      <div
+        {...getRootProps({
+          onDrop: (event) => {
+            event.stopPropagation(); // skips react-mediadrop's own drop handling
+          },
+        })}
+        className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+      >
+        <input {...getInputProps()} />
+        <p>Drag files here, or click to browse</p>
+      </div>
+      <ul className="space-y-2">
+        {acceptedFiles.map((file) => (
+          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
+            {file.name} — {file.size.toLocaleString()} bytes
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/examples-source/file-dialog.tsx
+++ b/apps/docs/examples-source/file-dialog.tsx
@@ -1,0 +1,25 @@
+import { useMediaDrop } from "react-mediadrop";
+
+export function FileDialogExample() {
+  const { acceptedFiles, getRootProps, getInputProps, open } = useMediaDrop({
+    noClick: true,
+    noKeyboard: true,
+  });
+
+  return (
+    <div className="space-y-3">
+      <div {...getRootProps()} className="rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
+        <input {...getInputProps()} />
+        <p>Drag files here — clicking the dropzone itself does nothing</p>
+        <button type="button" onClick={open}>Choose files</button>
+      </div>
+      <ul className="space-y-2">
+        {acceptedFiles.map((file) => (
+          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
+            {file.name} — {file.size.toLocaleString()} bytes
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/examples-source/file-dialog.tsx
+++ b/apps/docs/examples-source/file-dialog.tsx
@@ -1,25 +1,33 @@
 import { useMediaDrop } from "react-mediadrop";
 
 export function FileDialogExample() {
-  const { acceptedFiles, getRootProps, getInputProps, open } = useMediaDrop({
-    noClick: true,
-    noKeyboard: true,
-  });
+	const { acceptedFiles, getRootProps, getInputProps, open } = useMediaDrop({
+		noClick: true,
+		noKeyboard: true,
+	});
 
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here — clicking the dropzone itself does nothing</p>
-        <button type="button" onClick={open}>Choose files</button>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+	return (
+		<div className="space-y-3">
+			<div
+				{...getRootProps()}
+				className="rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+			>
+				<input {...getInputProps()} />
+				<p>Drag files here — clicking the dropzone itself does nothing</p>
+				<button type="button" onClick={open}>
+					Choose files
+				</button>
+			</div>
+			<ul className="space-y-2">
+				{acceptedFiles.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+					>
+						{file.name} — {file.size.toLocaleString()} bytes
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/forms.tsx
+++ b/apps/docs/examples-source/forms.tsx
@@ -1,32 +1,44 @@
-import { useMediaDrop } from "react-mediadrop";
 import { useEffect, useRef } from "react";
+import { useMediaDrop } from "react-mediadrop";
 
 export function FormsExample() {
-  const { acceptedFiles, getRootProps, getInputProps } = useMediaDrop();
-  const hiddenInputRef = useRef<HTMLInputElement>(null);
+	const { acceptedFiles, getRootProps, getInputProps } = useMediaDrop();
+	const hiddenInputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    if (!hiddenInputRef.current) return;
-    const dataTransfer = new DataTransfer();
-    for (const item of acceptedFiles) dataTransfer.items.add(item.file);
-    hiddenInputRef.current.files = dataTransfer.files;
-  }, [acceptedFiles]);
+	useEffect(() => {
+		if (!hiddenInputRef.current) return;
+		const dataTransfer = new DataTransfer();
+		for (const item of acceptedFiles) dataTransfer.items.add(item.file);
+		hiddenInputRef.current.files = dataTransfer.files;
+	}, [acceptedFiles]);
 
-  return (
-    <form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <input ref={hiddenInputRef} type="file" name="attachments" multiple className="hidden" />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-      </ul>
-      <button type="submit">Submit</button>
-    </form>
-  );
+	return (
+		<form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
+			<div
+				{...getRootProps()}
+				className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+			>
+				<input {...getInputProps()} />
+				<input
+					ref={hiddenInputRef}
+					type="file"
+					name="attachments"
+					multiple
+					className="hidden"
+				/>
+				<p>Drag files here, or click to browse</p>
+			</div>
+			<ul className="space-y-2">
+				{acceptedFiles.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+					>
+						{file.name} — {file.size.toLocaleString()} bytes
+					</li>
+				))}
+			</ul>
+			<button type="submit">Submit</button>
+		</form>
+	);
 }

--- a/apps/docs/examples-source/forms.tsx
+++ b/apps/docs/examples-source/forms.tsx
@@ -1,0 +1,32 @@
+import { useMediaDrop } from "react-mediadrop";
+import { useEffect, useRef } from "react";
+
+export function FormsExample() {
+  const { acceptedFiles, getRootProps, getInputProps } = useMediaDrop();
+  const hiddenInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!hiddenInputRef.current) return;
+    const dataTransfer = new DataTransfer();
+    for (const item of acceptedFiles) dataTransfer.items.add(item.file);
+    hiddenInputRef.current.files = dataTransfer.files;
+  }, [acceptedFiles]);
+
+  return (
+    <form className="space-y-3" onSubmit={(e) => e.preventDefault()}>
+      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
+        <input {...getInputProps()} />
+        <input ref={hiddenInputRef} type="file" name="attachments" multiple className="hidden" />
+        <p>Drag files here, or click to browse</p>
+      </div>
+      <ul className="space-y-2">
+        {acceptedFiles.map((file) => (
+          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
+            {file.name} — {file.size.toLocaleString()} bytes
+          </li>
+        ))}
+      </ul>
+      <button type="submit">Submit</button>
+    </form>
+  );
+}

--- a/apps/docs/examples-source/max-files.tsx
+++ b/apps/docs/examples-source/max-files.tsx
@@ -1,0 +1,27 @@
+import { useMediaDrop } from "react-mediadrop";
+
+export function MaxFilesExample() {
+  const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
+    useMediaDrop({ restrictions: { maxFiles: 3 } });
+
+  return (
+    <div className="space-y-3">
+      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
+        <input {...getInputProps()} />
+        <p>Drag files here, or click to browse</p>
+      </div>
+      <ul className="space-y-2">
+        {acceptedFiles.map((file) => (
+          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
+            {file.name} — {file.size.toLocaleString()} bytes
+          </li>
+        ))}
+        {rejectedFiles.map((file) => (
+          <li key={file.id} className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60">
+            {file.name} — {file.size.toLocaleString()} bytes · {file.errors[0]?.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/examples-source/max-files.tsx
+++ b/apps/docs/examples-source/max-files.tsx
@@ -1,27 +1,37 @@
 import { useMediaDrop } from "react-mediadrop";
 
 export function MaxFilesExample() {
-  const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
-    useMediaDrop({ restrictions: { maxFiles: 3 } });
+	const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
+		useMediaDrop({ restrictions: { maxFiles: 3 } });
 
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-        {rejectedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60">
-            {file.name} — {file.size.toLocaleString()} bytes · {file.errors[0]?.message}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+	return (
+		<div className="space-y-3">
+			<div
+				{...getRootProps()}
+				className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+			>
+				<input {...getInputProps()} />
+				<p>Drag files here, or click to browse</p>
+			</div>
+			<ul className="space-y-2">
+				{acceptedFiles.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+					>
+						{file.name} — {file.size.toLocaleString()} bytes
+					</li>
+				))}
+				{rejectedFiles.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60"
+					>
+						{file.name} — {file.size.toLocaleString()} bytes ·{" "}
+						{file.errors[0]?.message}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/presigned-url.tsx
+++ b/apps/docs/examples-source/presigned-url.tsx
@@ -3,46 +3,60 @@ import { useMediaDrop } from "react-mediadrop";
 import { createXhrUploadTransport } from "react-mediadrop/xhr-upload";
 
 export function PresignedUploadExample() {
-  const [urls, setUrls] = useState<Record<string, string>>({});
-  const requested = useRef(new Set<string>());
+	const [urls, setUrls] = useState<Record<string, string>>({});
+	const requested = useRef(new Set<string>());
 
-  const transport = createXhrUploadTransport({
-    formData: false, // send the raw file body, not multipart/form-data
-    endpoint: (file) => urls[file.id],
-  });
+	const transport = createXhrUploadTransport({
+		formData: false, // send the raw file body, not multipart/form-data
+		endpoint: (file) => urls[file.id],
+	});
 
-  const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({ transport });
+	const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({
+		transport,
+	});
 
-  useEffect(() => {
-    for (const file of files) {
-      if (file.status === "accepted" && file.uploadStatus === undefined && !requested.current.has(file.id)) {
-        requested.current.add(file.id);
-        fetch(`/api/presign?filename=${file.name}`)
-          .then((response) => response.json())
-          .then(({ url }) => {
-            setUrls((previous) => ({ ...previous, [file.id]: url }));
-            uploadFile(file.id);
-          });
-      }
-    }
-  }, [files, uploadFile]);
+	useEffect(() => {
+		for (const file of files) {
+			if (
+				file.status === "accepted" &&
+				file.uploadStatus === undefined &&
+				!requested.current.has(file.id)
+			) {
+				requested.current.add(file.id);
+				fetch(`/api/presign?filename=${file.name}`)
+					.then((response) => response.json())
+					.then(({ url }) => {
+						setUrls((previous) => ({ ...previous, [file.id]: url }));
+						uploadFile(file.id);
+					});
+			}
+		}
+	}, [files, uploadFile]);
 
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {files.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            <div className="flex items-center justify-between gap-2">
-              <span className="truncate">{file.name}</span>
-              <span className="text-xs text-zinc-500">{file.uploadStatus ?? file.status}</span>
-            </div>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+	return (
+		<div className="space-y-3">
+			<div
+				{...getRootProps()}
+				className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+			>
+				<input {...getInputProps()} />
+				<p>Drag files here, or click to browse</p>
+			</div>
+			<ul className="space-y-2">
+				{files.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+					>
+						<div className="flex items-center justify-between gap-2">
+							<span className="truncate">{file.name}</span>
+							<span className="text-xs text-zinc-500">
+								{file.uploadStatus ?? file.status}
+							</span>
+						</div>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/presigned-url.tsx
+++ b/apps/docs/examples-source/presigned-url.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from "react";
+import { useMediaDrop } from "react-mediadrop";
+import { createXhrUploadTransport } from "react-mediadrop/xhr-upload";
+
+export function PresignedUploadExample() {
+  const [urls, setUrls] = useState<Record<string, string>>({});
+  const requested = useRef(new Set<string>());
+
+  const transport = createXhrUploadTransport({
+    formData: false, // send the raw file body, not multipart/form-data
+    endpoint: (file) => urls[file.id],
+  });
+
+  const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({ transport });
+
+  useEffect(() => {
+    for (const file of files) {
+      if (file.status === "accepted" && file.uploadStatus === undefined && !requested.current.has(file.id)) {
+        requested.current.add(file.id);
+        fetch(`/api/presign?filename=${file.name}`)
+          .then((response) => response.json())
+          .then(({ url }) => {
+            setUrls((previous) => ({ ...previous, [file.id]: url }));
+            uploadFile(file.id);
+          });
+      }
+    }
+  }, [files, uploadFile]);
+
+  return (
+    <div className="space-y-3">
+      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
+        <input {...getInputProps()} />
+        <p>Drag files here, or click to browse</p>
+      </div>
+      <ul className="space-y-2">
+        {files.map((file) => (
+          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate">{file.name}</span>
+              <span className="text-xs text-zinc-500">{file.uploadStatus ?? file.status}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/examples-source/stackblitz-project.ts
+++ b/apps/docs/examples-source/stackblitz-project.ts
@@ -1,0 +1,58 @@
+export function buildStackblitzFiles(appCode: string) {
+  const componentName = appCode.match(/export function (\w+)/)?.[1] ?? "App";
+  return {
+    "package.json": JSON.stringify(
+      {
+        name: "react-mediadrop-example",
+        private: true,
+        version: "0.0.0",
+        type: "module",
+        scripts: {
+          dev: "vite",
+          build: "vite build",
+        },
+        dependencies: {
+          "react-mediadrop": "^0.1.1",
+          react: "^19.2.0",
+          "react-dom": "^19.2.0",
+        },
+        devDependencies: {
+          "@vitejs/plugin-react": "^6.0.3",
+          "@tailwindcss/vite": "^4",
+          tailwindcss: "^4",
+          vite: "^8.1.3",
+        },
+      },
+      null,
+      2,
+    ),
+    "index.html": `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>react-mediadrop example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>
+`,
+    "vite.config.ts": `import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+});
+`,
+    "src/main.tsx": `import { createRoot } from "react-dom/client";
+import { ${componentName} } from "./App";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(<${componentName} />);
+`,
+    "src/index.css": `@import "tailwindcss";\n`,
+    "src/App.tsx": appCode,
+  };
+}

--- a/apps/docs/examples-source/stackblitz-project.ts
+++ b/apps/docs/examples-source/stackblitz-project.ts
@@ -1,32 +1,32 @@
 export function buildStackblitzFiles(appCode: string) {
-  const componentName = appCode.match(/export function (\w+)/)?.[1] ?? "App";
-  return {
-    "package.json": JSON.stringify(
-      {
-        name: "react-mediadrop-example",
-        private: true,
-        version: "0.0.0",
-        type: "module",
-        scripts: {
-          dev: "vite",
-          build: "vite build",
-        },
-        dependencies: {
-          "react-mediadrop": "^0.1.1",
-          react: "^19.2.0",
-          "react-dom": "^19.2.0",
-        },
-        devDependencies: {
-          "@vitejs/plugin-react": "^6.0.3",
-          "@tailwindcss/vite": "^4",
-          tailwindcss: "^4",
-          vite: "^8.1.3",
-        },
-      },
-      null,
-      2,
-    ),
-    "index.html": `<!doctype html>
+	const componentName = appCode.match(/export function (\w+)/)?.[1] ?? "App";
+	return {
+		"package.json": JSON.stringify(
+			{
+				name: "react-mediadrop-example",
+				private: true,
+				version: "0.0.0",
+				type: "module",
+				scripts: {
+					dev: "vite",
+					build: "vite build",
+				},
+				dependencies: {
+					"react-mediadrop": "^0.1.1",
+					react: "^19.2.0",
+					"react-dom": "^19.2.0",
+				},
+				devDependencies: {
+					"@vitejs/plugin-react": "^6.0.3",
+					"@tailwindcss/vite": "^4",
+					tailwindcss: "^4",
+					vite: "^8.1.3",
+				},
+			},
+			null,
+			2,
+		),
+		"index.html": `<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -38,7 +38,7 @@ export function buildStackblitzFiles(appCode: string) {
   </body>
 </html>
 `,
-    "vite.config.ts": `import { defineConfig } from "vite";
+		"vite.config.ts": `import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 
@@ -46,13 +46,13 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
 });
 `,
-    "src/main.tsx": `import { createRoot } from "react-dom/client";
+		"src/main.tsx": `import { createRoot } from "react-dom/client";
 import { ${componentName} } from "./App";
 import "./index.css";
 
 createRoot(document.getElementById("root")!).render(<${componentName} />);
 `,
-    "src/index.css": `@import "tailwindcss";\n`,
-    "src/App.tsx": appCode,
-  };
+		"src/index.css": `@import "tailwindcss";\n`,
+		"src/App.tsx": appCode,
+	};
 }

--- a/apps/docs/examples-source/styling.tsx
+++ b/apps/docs/examples-source/styling.tsx
@@ -1,0 +1,47 @@
+import { useMediaDrop } from "react-mediadrop";
+
+export function StylingExample() {
+  const {
+    acceptedFiles,
+    getRootProps,
+    getInputProps,
+    isFocused,
+    isDragActive,
+    isDragAccept,
+    isDragReject,
+  } = useMediaDrop({ restrictions: { accept: ["image/*"] } });
+
+  const border =
+    isDragAccept ? "border-green-500"
+    : isDragReject ? "border-red-500"
+    : isDragActive ? "border-sky-500"
+    : isFocused ? "border-sky-600"
+    : "border-zinc-300 dark:border-zinc-700";
+
+  return (
+    <div className="w-full space-y-3">
+      <div
+        {...getRootProps()}
+        className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center ${border}`}
+      >
+        <input {...getInputProps()} />
+        <p>Drag an image here, or click to browse</p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-xs">
+        <span>isFocused: {String(isFocused)}</span>
+        <span>isDragActive: {String(isDragActive)}</span>
+        <span>isDragAccept: {String(isDragAccept)}</span>
+        <span>isDragReject: {String(isDragReject)}</span>
+      </div>
+
+      <ul className="m-0 w-full list-none space-y-2 p-0">
+        {acceptedFiles.map((file) => (
+          <li key={file.id}>
+            {file.name} — {file.size.toLocaleString()} bytes
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/examples-source/styling.tsx
+++ b/apps/docs/examples-source/styling.tsx
@@ -1,47 +1,50 @@
 import { useMediaDrop } from "react-mediadrop";
 
 export function StylingExample() {
-  const {
-    acceptedFiles,
-    getRootProps,
-    getInputProps,
-    isFocused,
-    isDragActive,
-    isDragAccept,
-    isDragReject,
-  } = useMediaDrop({ restrictions: { accept: ["image/*"] } });
+	const {
+		acceptedFiles,
+		getRootProps,
+		getInputProps,
+		isFocused,
+		isDragActive,
+		isDragAccept,
+		isDragReject,
+	} = useMediaDrop({ restrictions: { accept: ["image/*"] } });
 
-  const border =
-    isDragAccept ? "border-green-500"
-    : isDragReject ? "border-red-500"
-    : isDragActive ? "border-sky-500"
-    : isFocused ? "border-sky-600"
-    : "border-zinc-300 dark:border-zinc-700";
+	const border = isDragAccept
+		? "border-green-500"
+		: isDragReject
+			? "border-red-500"
+			: isDragActive
+				? "border-sky-500"
+				: isFocused
+					? "border-sky-600"
+					: "border-zinc-300 dark:border-zinc-700";
 
-  return (
-    <div className="w-full space-y-3">
-      <div
-        {...getRootProps()}
-        className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center ${border}`}
-      >
-        <input {...getInputProps()} />
-        <p>Drag an image here, or click to browse</p>
-      </div>
+	return (
+		<div className="w-full space-y-3">
+			<div
+				{...getRootProps()}
+				className={`cursor-pointer rounded-lg border-2 border-dashed px-6 py-10 text-center ${border}`}
+			>
+				<input {...getInputProps()} />
+				<p>Drag an image here, or click to browse</p>
+			</div>
 
-      <div className="flex flex-wrap gap-2 text-xs">
-        <span>isFocused: {String(isFocused)}</span>
-        <span>isDragActive: {String(isDragActive)}</span>
-        <span>isDragAccept: {String(isDragAccept)}</span>
-        <span>isDragReject: {String(isDragReject)}</span>
-      </div>
+			<div className="flex flex-wrap gap-2 text-xs">
+				<span>isFocused: {String(isFocused)}</span>
+				<span>isDragActive: {String(isDragActive)}</span>
+				<span>isDragAccept: {String(isDragAccept)}</span>
+				<span>isDragReject: {String(isDragReject)}</span>
+			</div>
 
-      <ul className="m-0 w-full list-none space-y-2 p-0">
-        {acceptedFiles.map((file) => (
-          <li key={file.id}>
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+			<ul className="m-0 w-full list-none space-y-2 p-0">
+				{acceptedFiles.map((file) => (
+					<li key={file.id}>
+						{file.name} — {file.size.toLocaleString()} bytes
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/upload-progress.tsx
+++ b/apps/docs/examples-source/upload-progress.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from "react";
+import { createHttpError, useMediaDrop, type UploadTransport } from "react-mediadrop";
+
+const transport: UploadTransport = {
+  upload(file, { onProgress, signal }) {
+    return new Promise((resolve, reject) => {
+      const total = file.size;
+      const durationMs = 1500;
+      const start = performance.now();
+
+      const onAbort = () => {
+        clearInterval(interval);
+        reject(createHttpError("Aborted"));
+      };
+
+      const interval = setInterval(() => {
+        const elapsed = performance.now() - start;
+        const loaded = Math.min(total, Math.round((elapsed / durationMs) * total));
+        onProgress({ loaded, total });
+
+        if (elapsed >= durationMs) {
+          clearInterval(interval);
+          signal.removeEventListener("abort", onAbort);
+          resolve({ response: { simulated: true } });
+        }
+      }, 100);
+
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+  },
+};
+
+export function UploadProgressExample() {
+  const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({ transport });
+
+  useEffect(() => {
+    for (const file of files) {
+      if (file.status === "accepted" && file.uploadStatus === undefined) {
+        uploadFile(file.id);
+      }
+    }
+  }, [files, uploadFile]);
+
+  return (
+    <div className="space-y-3">
+      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
+        <input {...getInputProps()} />
+        <p>Drag files here, or click to browse</p>
+      </div>
+      <ul className="space-y-2">
+        {files.map((file) => (
+          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
+            <div className="flex justify-between">
+              <span>{file.name}</span>
+              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes · {file.uploadStatus ?? file.status}</span>
+            </div>
+            <progress
+              className="mt-2 h-1.5 w-full"
+              value={file.progress?.loaded ?? 0}
+              max={file.progress?.total ?? file.size}
+            />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/examples-source/upload-progress.tsx
+++ b/apps/docs/examples-source/upload-progress.tsx
@@ -1,67 +1,85 @@
 import { useEffect } from "react";
-import { createHttpError, useMediaDrop, type UploadTransport } from "react-mediadrop";
+import {
+	createHttpError,
+	type UploadTransport,
+	useMediaDrop,
+} from "react-mediadrop";
 
 const transport: UploadTransport = {
-  upload(file, { onProgress, signal }) {
-    return new Promise((resolve, reject) => {
-      const total = file.size;
-      const durationMs = 1500;
-      const start = performance.now();
+	upload(file, { onProgress, signal }) {
+		return new Promise((resolve, reject) => {
+			const total = file.size;
+			const durationMs = 1500;
+			const start = performance.now();
 
-      const onAbort = () => {
-        clearInterval(interval);
-        reject(createHttpError("Aborted"));
-      };
+			const onAbort = () => {
+				clearInterval(interval);
+				reject(createHttpError("Aborted"));
+			};
 
-      const interval = setInterval(() => {
-        const elapsed = performance.now() - start;
-        const loaded = Math.min(total, Math.round((elapsed / durationMs) * total));
-        onProgress({ loaded, total });
+			const interval = setInterval(() => {
+				const elapsed = performance.now() - start;
+				const loaded = Math.min(
+					total,
+					Math.round((elapsed / durationMs) * total),
+				);
+				onProgress({ loaded, total });
 
-        if (elapsed >= durationMs) {
-          clearInterval(interval);
-          signal.removeEventListener("abort", onAbort);
-          resolve({ response: { simulated: true } });
-        }
-      }, 100);
+				if (elapsed >= durationMs) {
+					clearInterval(interval);
+					signal.removeEventListener("abort", onAbort);
+					resolve({ response: { simulated: true } });
+				}
+			}, 100);
 
-      signal.addEventListener("abort", onAbort, { once: true });
-    });
-  },
+			signal.addEventListener("abort", onAbort, { once: true });
+		});
+	},
 };
 
 export function UploadProgressExample() {
-  const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({ transport });
+	const { files, getRootProps, getInputProps, uploadFile } = useMediaDrop({
+		transport,
+	});
 
-  useEffect(() => {
-    for (const file of files) {
-      if (file.status === "accepted" && file.uploadStatus === undefined) {
-        uploadFile(file.id);
-      }
-    }
-  }, [files, uploadFile]);
+	useEffect(() => {
+		for (const file of files) {
+			if (file.status === "accepted" && file.uploadStatus === undefined) {
+				uploadFile(file.id);
+			}
+		}
+	}, [files, uploadFile]);
 
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {files.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            <div className="flex justify-between">
-              <span>{file.name}</span>
-              <span className="text-xs text-zinc-500">{file.size.toLocaleString()} bytes · {file.uploadStatus ?? file.status}</span>
-            </div>
-            <progress
-              className="mt-2 h-1.5 w-full"
-              value={file.progress?.loaded ?? 0}
-              max={file.progress?.total ?? file.size}
-            />
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+	return (
+		<div className="space-y-3">
+			<div
+				{...getRootProps()}
+				className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+			>
+				<input {...getInputProps()} />
+				<p>Drag files here, or click to browse</p>
+			</div>
+			<ul className="space-y-2">
+				{files.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+					>
+						<div className="flex justify-between">
+							<span>{file.name}</span>
+							<span className="text-xs text-zinc-500">
+								{file.size.toLocaleString()} bytes ·{" "}
+								{file.uploadStatus ?? file.status}
+							</span>
+						</div>
+						<progress
+							className="mt-2 h-1.5 w-full"
+							value={file.progress?.loaded ?? 0}
+							max={file.progress?.total ?? file.size}
+						/>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/validator.tsx
+++ b/apps/docs/examples-source/validator.tsx
@@ -1,34 +1,47 @@
 import { useMediaDrop } from "react-mediadrop";
 
 function noSpacesValidator(file: File) {
-  if (file.name.includes(" ")) {
-    return { code: "validator-error" as const, message: "Filenames can't contain spaces" };
-  }
-  return null;
+	if (file.name.includes(" ")) {
+		return {
+			code: "validator-error" as const,
+			message: "Filenames can't contain spaces",
+		};
+	}
+	return null;
 }
 
 export function ValidatorExample() {
-  const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
-    useMediaDrop({ validator: noSpacesValidator });
+	const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
+		useMediaDrop({ validator: noSpacesValidator });
 
-  return (
-    <div className="space-y-3">
-      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
-        <input {...getInputProps()} />
-        <p>Drag files here, or click to browse</p>
-      </div>
-      <ul className="space-y-2">
-        {acceptedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
-            {file.name} — {file.size.toLocaleString()} bytes
-          </li>
-        ))}
-        {rejectedFiles.map((file) => (
-          <li key={file.id} className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60">
-            {file.name} — {file.size.toLocaleString()} bytes · {file.errors?.[0]?.message}
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
+	return (
+		<div className="space-y-3">
+			<div
+				{...getRootProps()}
+				className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700"
+			>
+				<input {...getInputProps()} />
+				<p>Drag files here, or click to browse</p>
+			</div>
+			<ul className="space-y-2">
+				{acceptedFiles.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800"
+					>
+						{file.name} — {file.size.toLocaleString()} bytes
+					</li>
+				))}
+				{rejectedFiles.map((file) => (
+					<li
+						key={file.id}
+						className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60"
+					>
+						{file.name} — {file.size.toLocaleString()} bytes ·{" "}
+						{file.errors?.[0]?.message}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
 }

--- a/apps/docs/examples-source/validator.tsx
+++ b/apps/docs/examples-source/validator.tsx
@@ -1,0 +1,34 @@
+import { useMediaDrop } from "react-mediadrop";
+
+function noSpacesValidator(file: File) {
+  if (file.name.includes(" ")) {
+    return { code: "validator-error" as const, message: "Filenames can't contain spaces" };
+  }
+  return null;
+}
+
+export function ValidatorExample() {
+  const { acceptedFiles, rejectedFiles, getRootProps, getInputProps } =
+    useMediaDrop({ validator: noSpacesValidator });
+
+  return (
+    <div className="space-y-3">
+      <div {...getRootProps()} className="cursor-pointer rounded-lg border-2 border-dashed border-zinc-300 px-6 py-10 text-center dark:border-zinc-700">
+        <input {...getInputProps()} />
+        <p>Drag files here, or click to browse</p>
+      </div>
+      <ul className="space-y-2">
+        {acceptedFiles.map((file) => (
+          <li key={file.id} className="rounded-md border border-zinc-200 px-3 py-2 text-sm dark:border-zinc-800">
+            {file.name} — {file.size.toLocaleString()} bytes
+          </li>
+        ))}
+        {rejectedFiles.map((file) => (
+          <li key={file.id} className="rounded-md border border-red-200 px-3 py-2 text-sm dark:border-red-900/60">
+            {file.name} — {file.size.toLocaleString()} bytes · {file.errors?.[0]?.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/docs/islands/ExampleCodeHeader.tsx
+++ b/apps/docs/islands/ExampleCodeHeader.tsx
@@ -1,121 +1,121 @@
-import { useState } from "react";
 import sdk from "@stackblitz/sdk";
+import { useState } from "react";
 import { buildStackblitzFiles } from "../examples-source/stackblitz-project";
 
 interface ExampleCodeHeaderProps {
-  code: string;
-  title: string;
-  description?: string;
+	code: string;
+	title: string;
+	description?: string;
 }
 
 export default function ExampleCodeHeader({
-  code,
-  title,
-  description = "Live example from the react-mediadrop docs.",
+	code,
+	title,
+	description = "Live example from the react-mediadrop docs.",
 }: ExampleCodeHeaderProps) {
-  const [copied, setCopied] = useState(false);
+	const [copied, setCopied] = useState(false);
 
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
-  };
+	const handleCopy = async () => {
+		await navigator.clipboard.writeText(code);
+		setCopied(true);
+		setTimeout(() => setCopied(false), 1500);
+	};
 
-  const handleOpen = () => {
-    sdk.openProject(
-      {
-        title,
-        description,
-        template: "node",
-        files: buildStackblitzFiles(code),
-      },
-      { newWindow: true, openFile: "src/App.tsx" },
-    );
-  };
+	const handleOpen = () => {
+		sdk.openProject(
+			{
+				title,
+				description,
+				template: "node",
+				files: buildStackblitzFiles(code),
+			},
+			{ newWindow: true, openFile: "src/App.tsx" },
+		);
+	};
 
-  return (
-    <div
-      data-example-header=""
-      className="not-prose flex h-11 items-center justify-between rounded-t-[var(--blume-radius)] border border-b-0 border-[var(--blume-border)] bg-[var(--blume-code-background)] px-4"
-    >
-      <span className="inline-flex items-center gap-2 text-xs font-medium text-muted-foreground">
-        <svg
-          aria-hidden="true"
-          viewBox="0 0 24 24"
-          width="14"
-          height="14"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <polyline points="16 18 22 12 16 6" />
-          <polyline points="8 6 2 12 8 18" />
-        </svg>
-        TSX
-      </span>
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={handleCopy}
-          aria-label="Copy code"
-          className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground"
-        >
-          {copied ? (
-            <svg
-              aria-hidden="true"
-              viewBox="0 0 24 24"
-              width="14"
-              height="14"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="20 6 9 17 4 12" />
-            </svg>
-          ) : (
-            <svg
-              aria-hidden="true"
-              viewBox="0 0 24 24"
-              width="14"
-              height="14"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <rect x="9" y="9" width="13" height="13" rx="2" />
-              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
-            </svg>
-          )}
-        </button>
-        <button
-          type="button"
-          onClick={handleOpen}
-          className="inline-flex items-center gap-1.5 rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-zinc-50 transition-colors hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
-        >
-          <svg
-            aria-hidden="true"
-            viewBox="0 0 24 24"
-            width="12"
-            height="12"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-            <path d="M15 3h6v6" />
-            <path d="M10 14 21 3" />
-          </svg>
-          Open in StackBlitz
-        </button>
-      </div>
-    </div>
-  );
+	return (
+		<div
+			data-example-header=""
+			className="not-prose flex h-11 items-center justify-between rounded-t-[var(--blume-radius)] border border-b-0 border-[var(--blume-border)] bg-[var(--blume-code-background)] px-4"
+		>
+			<span className="inline-flex items-center gap-2 text-xs font-medium text-muted-foreground">
+				<svg
+					aria-hidden="true"
+					viewBox="0 0 24 24"
+					width="14"
+					height="14"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+				>
+					<polyline points="16 18 22 12 16 6" />
+					<polyline points="8 6 2 12 8 18" />
+				</svg>
+				TSX
+			</span>
+			<div className="flex items-center gap-2">
+				<button
+					type="button"
+					onClick={handleCopy}
+					aria-label="Copy code"
+					className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground"
+				>
+					{copied ? (
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							width="14"
+							height="14"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+						>
+							<polyline points="20 6 9 17 4 12" />
+						</svg>
+					) : (
+						<svg
+							aria-hidden="true"
+							viewBox="0 0 24 24"
+							width="14"
+							height="14"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+						>
+							<rect x="9" y="9" width="13" height="13" rx="2" />
+							<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+						</svg>
+					)}
+				</button>
+				<button
+					type="button"
+					onClick={handleOpen}
+					className="inline-flex items-center gap-1.5 rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-zinc-50 transition-colors hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+				>
+					<svg
+						aria-hidden="true"
+						viewBox="0 0 24 24"
+						width="12"
+						height="12"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					>
+						<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+						<path d="M15 3h6v6" />
+						<path d="M10 14 21 3" />
+					</svg>
+					Open in StackBlitz
+				</button>
+			</div>
+		</div>
+	);
 }

--- a/apps/docs/islands/ExampleCodeHeader.tsx
+++ b/apps/docs/islands/ExampleCodeHeader.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import sdk from "@stackblitz/sdk";
+import { buildStackblitzFiles } from "../examples-source/stackblitz-project";
+
+interface ExampleCodeHeaderProps {
+  code: string;
+  title: string;
+  description?: string;
+}
+
+export default function ExampleCodeHeader({
+  code,
+  title,
+  description = "Live example from the react-mediadrop docs.",
+}: ExampleCodeHeaderProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  const handleOpen = () => {
+    sdk.openProject(
+      {
+        title,
+        description,
+        template: "node",
+        files: buildStackblitzFiles(code),
+      },
+      { newWindow: true, openFile: "src/App.tsx" },
+    );
+  };
+
+  return (
+    <div
+      data-example-header=""
+      className="not-prose flex h-11 items-center justify-between rounded-t-[var(--blume-radius)] border border-b-0 border-[var(--blume-border)] bg-[var(--blume-code-background)] px-4"
+    >
+      <span className="inline-flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        <svg
+          aria-hidden="true"
+          viewBox="0 0 24 24"
+          width="14"
+          height="14"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <polyline points="16 18 22 12 16 6" />
+          <polyline points="8 6 2 12 8 18" />
+        </svg>
+        TSX
+      </span>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label="Copy code"
+          className="inline-flex size-7 items-center justify-center rounded-full text-muted-foreground transition hover:bg-muted hover:text-foreground"
+        >
+          {copied ? (
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+              width="14"
+              height="14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          ) : (
+            <svg
+              aria-hidden="true"
+              viewBox="0 0 24 24"
+              width="14"
+              height="14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+          )}
+        </button>
+        <button
+          type="button"
+          onClick={handleOpen}
+          className="inline-flex items-center gap-1.5 rounded-md bg-zinc-900 px-3 py-1.5 text-xs font-medium text-zinc-50 transition-colors hover:bg-zinc-800 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+        >
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            width="12"
+            height="12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+            <path d="M15 3h6v6" />
+            <path d="M10 14 21 3" />
+          </svg>
+          Open in StackBlitz
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,6 +26,7 @@
 		"@scalar/openapi-types": "^0.9.1",
 		"@shikijs/transformers": "^4.2.0",
 		"@shikijs/twoslash": "^4.2.0",
+		"@stackblitz/sdk": "^1.11.1",
 		"@tailwindcss/typography": "^0.5.20",
 		"@tailwindcss/vite": "^4",
 		"@takumi-rs/core": "^1.8.7",

--- a/apps/docs/theme.css
+++ b/apps/docs/theme.css
@@ -15,3 +15,21 @@ header[data-blume-header] a[href="/"] span:not([aria-hidden]) {
 img[alt="react-mediadrop"] {
 	height: 24px;
 }
+
+/* Docs example code blocks: a custom header (TSX label, copy, Open in
+   StackBlitz) sits flush above a headerless <CodeBlock>, so the two read as
+   one panel. Blume's own copy button still auto-attaches to any .prose pre;
+   suppress it here since the header already has one. */
+astro-island:has(+ astro-island [data-example-header]) > div {
+	margin-bottom: 1.5rem;
+}
+
+astro-island:has([data-example-header]) + div.prose > pre {
+	margin-top: 0;
+	border-top-left-radius: 0;
+	border-top-right-radius: 0;
+}
+
+astro-island:has([data-example-header]) + div.prose pre [data-blume-copy] {
+	display: none;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -303,6 +303,9 @@ importers:
       '@shikijs/twoslash':
         specifier: ^4.2.0
         version: 4.3.1(typescript@5.9.3)
+      '@stackblitz/sdk':
+        specifier: ^1.11.1
+        version: 1.11.1
       '@tailwindcss/typography':
         specifier: ^0.5.20
         version: 0.5.20(tailwindcss@4.3.2)
@@ -1820,6 +1823,9 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@stackblitz/sdk@1.11.1':
+    resolution: {integrity: sha512-5wl1j3IhtmE7POTl2W9VGQdbQyBQrRsF3jcYBK+0V353AuO8H2GFZkiFNyTRxL+TDY3HIFCHc3G983Osmg76Lg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -6765,6 +6771,8 @@ snapshots:
   '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@stackblitz/sdk@1.11.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 


### PR DESCRIPTION
## Summary
- Extend the ExampleCodeHeader/StackBlitz pattern (from the basics examples) to the 4 uploads examples: cancel-retry, concurrency, presigned-url, upload-progress.
- Add a new self-contained, prop-less file per example under `examples-source/`, single-sourced (via `?raw` import) into both the live demo island and the displayed `<CodeBlock>` — replacing fenced code blocks that took a `transport` prop and couldn't run standalone in StackBlitz.
- `cancel-retry` and `concurrency` get inline mock transports (interval-based progress, one-shot failure/retry toggle for cancel-retry); `upload-progress` keeps its simulated transport; `presigned-url` keeps the real `createXhrUploadTransport` and fleshes out the previously-stubbed file list render.
- Biome formatting pass (tabs, sorted imports) across all `examples-source/*.tsx` and `ExampleCodeHeader.tsx`, including the pre-existing basics files.

## Test plan
- [x] `blume build --strict --isolated` — no errors, 28 pages built
- [x] `biome check` — clean across examples-source, islands, and mdx files
- [x] All 4 uploads example pages verified live in browser (dark + light mode): demo renders, Open in StackBlitz button present, code block flush with header
- [x] Sidebar nav shows all 4 uploads pages correctly linked

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive documentation examples covering file acceptance, validation, drag states, forms, upload progress, cancellation, retries, concurrency, and presigned uploads.
  * Added “Copy code” and “Open in StackBlitz” actions to code examples.
  * Examples now display live previews alongside synchronized source code.

* **Documentation**
  * Standardized example presentation across the documentation with consistent headers and code blocks.
  * Improved styling and spacing for integrated example previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->