### PR TITLE
fix: stop doubling /docs in canonical, og, and sitemap URLs

### DIFF
--- a/apps/docs/blume.config.ts
+++ b/apps/docs/blume.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
 	},
 	deployment: {
 		base: "/docs",
-		site: "https://www.mediadrop.dev/docs",
+		site: "https://www.mediadrop.dev",
 	},
 	analytics: {
 		posthog: {


### PR DESCRIPTION
## Summary
- `deployment.site` was set to `https://www.mediadrop.dev/docs`, but blume already prepends `deployment.base` ("/docs") onto site-relative URLs via `withBase()`. With both set, every canonical link, `og:url`, `og:image`, and sitemap entry resolved to `.../docs/docs/...` and 404'd (e.g. https://www.mediadrop.dev/docs/docs/og/examples/accept.png).
- Fix: set `deployment.site` to the bare origin (`https://www.mediadrop.dev`); `deployment.base` alone handles the `/docs` subpath, matching Astro's own `site`/`base` convention that blume follows internally.

## Test plan
- [x] `blume build --strict --isolated` — no errors
- [x] Verified `examples/accept` build output: canonical, `og:url`, and `og:image` now resolve to single `/docs/...` (previously doubled)
- [x] Confirmed the corrected OG image route (`/docs/og/examples/accept.png`) returns 200 on production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated documentation site configuration so links and deployments correctly use the site’s root URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->