### PR TITLE
chore(deps): pin tar to >=7.5.19 (critical/high advisory)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,7 @@ catalogs:
 
 overrides:
   path-to-regexp@>=4.0.0 <6.3.0: '>=6.3.0'
+  tar@<7.5.19: '>=7.5.19'
 
 importers:
 
@@ -4812,8 +4813,8 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  tar@7.5.15:
-    resolution: {integrity: sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==}
+  tar@7.5.20:
+    resolution: {integrity: sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==}
     engines: {node: '>=18'}
 
   term-size@2.2.1:
@@ -6432,7 +6433,7 @@ snapshots:
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.8.5
-      tar: 7.5.15
+      tar: 7.5.20
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -10326,7 +10327,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  tar@7.5.15:
+  tar@7.5.20:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ allowBuilds:
 
 overrides:
   "path-to-regexp@>=4.0.0 <6.3.0": ">=6.3.0"
+  "tar@<7.5.19": ">=7.5.19"
 
 catalog:
   typescript: ^5.9.3


### PR DESCRIPTION
## Summary
- `tar@7.5.15` — pulled in transitively via `@mapbox/node-pre-gyp` > `@vercel/nft` > `@astrojs/vercel`/`blume` — has a critical decompression DoS ([GHSA-23hp-3jrh-7fpw](https://github.com/advisories/GHSA-23hp-3jrh-7fpw)) and a high infinite-loop advisory ([GHSA-8x88-c5mf-7j5w](https://github.com/advisories/GHSA-8x88-c5mf-7j5w)), both failing `pnpm audit --audit-level=high` in CI (currently red on `main`).
- Added a `pnpm-workspace.yaml` override pinning `tar` to `>=7.5.19`, the same pattern already used for `path-to-regexp`.

## Test plan
- [x] `pnpm install` — lockfile regenerated, `tar` resolves to 7.5.20
- [x] `pnpm audit --audit-level=high` — 0 critical/high (3 remaining low/moderate, below threshold)
- [x] `pnpm lint` (biome) — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package resolution to require a secure minimum version of the `tar` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->