### PR TITLE
Add Context7 library config and refresh-on-push workflow

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -1,0 +1,17 @@
+name: Refresh Context7 Docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Context7 Refresh
+        run: |
+          curl -s -X POST https://context7.com/api/v1/refresh \
+            -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ secrets.CONTEXT7_API_KEY }}" \
+            -d '{"libraryName": "/${{ github.repository }}"}'

--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Trigger Context7 Refresh
         run: |
-          curl -s -X POST https://context7.com/api/v1/refresh \
+          curl -s --fail-with-body --show-error -X POST https://context7.com/api/v1/refresh \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.CONTEXT7_API_KEY }}" \
             -d '{"libraryName": "/${{ github.repository }}"}'

--- a/context7.json
+++ b/context7.json
@@ -1,11 +1,11 @@
 {
-  "$schema": "https://context7.com/schema/context7.json",
-  "projectTitle": "react-mediadrop",
-  "description": "A lightweight, headless-first file uploader for React — drag-and-drop, validation, and a pluggable upload queue with concurrency, retry, and cancel support.",
-  "folders": ["apps/docs/docs"],
-  "rules": [
-    "react-mediadrop is headless — it has no bundled UI components, only the useMediaDrop hook and transport contract",
-    "Do not invent APIs that aren't documented here — check apps/docs/docs/reference for the exact exported types and hook signature",
-    "Uploads require a transport implementing UploadTransport, supplied via useMediaDrop({ transport }); react-mediadrop/xhr-upload provides createXhrUploadTransport() as a reference transport"
-  ]
+	"$schema": "https://context7.com/schema/context7.json",
+	"projectTitle": "react-mediadrop",
+	"description": "A lightweight, headless-first file uploader for React — drag-and-drop, validation, and a pluggable upload queue with concurrency, retry, and cancel support.",
+	"folders": ["apps/docs/docs"],
+	"rules": [
+		"react-mediadrop is headless — it has no bundled UI components, only the useMediaDrop hook and transport contract",
+		"Do not invent APIs that aren't documented here — check apps/docs/docs/reference for the exact exported types and hook signature",
+		"Uploads require a transport implementing UploadTransport, supplied via useMediaDrop({ transport }); react-mediadrop/xhr-upload provides createXhrUploadTransport() as a reference transport"
+	]
 }

--- a/context7.json
+++ b/context7.json
@@ -6,6 +6,6 @@
   "rules": [
     "react-mediadrop is headless — it has no bundled UI components, only the useMediaDrop hook and transport contract",
     "Do not invent APIs that aren't documented here — check apps/docs/docs/reference for the exact exported types and hook signature",
-    "Uploads require a transport implementing UploadTransport; react-mediadrop/xhr-upload provides the built-in XHR transport"
+    "Uploads require a transport implementing UploadTransport, supplied via useMediaDrop({ transport }); react-mediadrop/xhr-upload provides createXhrUploadTransport() as a reference transport"
   ]
 }

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "react-mediadrop",
+  "description": "A lightweight, headless-first file uploader for React — drag-and-drop, validation, and a pluggable upload queue with concurrency, retry, and cancel support.",
+  "folders": ["apps/docs/docs"],
+  "rules": [
+    "react-mediadrop is headless — it has no bundled UI components, only the useMediaDrop hook and transport contract",
+    "Do not invent APIs that aren't documented here — check apps/docs/docs/reference for the exact exported types and hook signature",
+    "Uploads require a transport implementing UploadTransport; react-mediadrop/xhr-upload provides the built-in XHR transport"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `context7.json` scoping Context7's index to `apps/docs/docs`, with project title/description and rules so agents don't invent APIs (headless-only, no bundled UI, use the documented `UploadTransport` contract)
- Adds `.github/workflows/context7-refresh.yml` to trigger a Context7 docs refresh on every push to `main`

## Setup needed after merge
- Add a `CONTEXT7_API_KEY` repo secret (Settings → Secrets and variables → Actions) so the refresh workflow can authenticate
- Submit the repo to Context7 via the dashboard's "Add Docs" → GitHub flow, using `https://github.com/autorender/react-mediadrop`

## Test plan
- [ ] Merge and confirm `context7-refresh.yml` runs on the merge commit (will no-op auth-wise until the secret is added)
- [ ] Add `CONTEXT7_API_KEY` secret
- [ ] Submit repo to Context7, confirm it picks up `context7.json` scoping on first parse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added project context guidance defining the documentation setup and a headless-first approach, including supported media upload interfaces and references.
* **Chores**
  * Added an automated GitHub Actions workflow to refresh the Context7 documentation on every push to the main branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->