### PR TITLE
chore: add Context7 ownership verification fields

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -7,5 +7,7 @@
 		"react-mediadrop is headless — it has no bundled UI components, only the useMediaDrop hook and transport contract",
 		"Do not invent APIs that aren't documented here — check apps/docs/docs/reference for the exact exported types and hook signature",
 		"Uploads require a transport implementing UploadTransport, supplied via useMediaDrop({ transport }); react-mediadrop/xhr-upload provides createXhrUploadTransport() as a reference transport"
-	]
+	],
+	"url": "https://context7.com/autorender/react-mediadrop",
+	"public_key": "pk_PCyxdZsEJXso54WeXMitO"
 }


### PR DESCRIPTION
## Summary
- Adds `url` and `public_key` to `context7.json` per Context7's ownership-verification flow (Claim Library dialog), so the repo can be claimed on the Context7 dashboard.

## Test plan
- [x] `biome check context7.json` passes
- [ ] After merge, click "Claim Library" on the Context7 dashboard to complete verification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added service connection details to support the latest application configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->