### PR TITLE
fix: tolerate Context7's 10-day refresh cooldown in CI

### DIFF
--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -21,7 +21,7 @@ jobs:
           if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
             exit 0
           fi
-          if grep -q '"error":"too-early"' <<< "$body"; then
+          if [ "$http_code" -eq 400 ] && jq -e '.error == "too-early"' <<< "$body" > /dev/null 2>&1; then
             echo "Refresh skipped: still within Context7's cooldown window."
             exit 0
           fi

--- a/.github/workflows/context7-refresh.yml
+++ b/.github/workflows/context7-refresh.yml
@@ -11,7 +11,18 @@ jobs:
     steps:
       - name: Trigger Context7 Refresh
         run: |
-          curl -s --fail-with-body --show-error -X POST https://context7.com/api/v1/refresh \
+          response=$(curl -s --show-error -w '\n%{http_code}' -X POST https://context7.com/api/v1/refresh \
             -H "Content-Type: application/json" \
             -H "Authorization: Bearer ${{ secrets.CONTEXT7_API_KEY }}" \
-            -d '{"libraryName": "/${{ github.repository }}"}'
+            -d '{"libraryName": "/${{ github.repository }}"}')
+          http_code=$(tail -n1 <<< "$response")
+          body=$(sed '$d' <<< "$response")
+          echo "$body"
+          if [ "$http_code" -ge 200 ] && [ "$http_code" -lt 300 ]; then
+            exit 0
+          fi
+          if grep -q '"error":"too-early"' <<< "$body"; then
+            echo "Refresh skipped: still within Context7's cooldown window."
+            exit 0
+          fi
+          exit 1


### PR DESCRIPTION
## Summary
- The `context7-refresh.yml` workflow triggers on every push to `main`, but Context7's refresh API rejects requests within 10 days of the last update (`400 {"error":"too-early"}`). The previous `--fail-with-body` treated that expected response as a hard CI failure.
- Now checks the HTTP status/body explicitly: 2xx succeeds, a `too-early` 400 is logged and treated as a no-op success, anything else (auth errors, 404, 5xx) still fails the job.

## Test plan
- [x] Verified locally against mocked success / too-early / not-found responses — only the genuine-error case exits non-zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the automated Context7 refresh step to evaluate success using HTTP status and response content.
  * Treated expected cooldown responses (HTTP 400 with a “too-early” error) as non-fatal, avoiding false failures.
  * Enhanced logging by printing the raw response body and status code for easier troubleshooting when unexpected errors occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->