### PR TITLE
docs: lead with react-dropzone versus framing, surface skills + registry install

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@
 
 ## Introduction
 
-**mediadrop** is a hooks-first, headless file uploader for React — file
-intake, drag/drop, validation, and upload (queue, concurrency, retry,
-cancel) via a single `useMediaDrop` hook. No prebuilt widget — you own the
-markup.
+**mediadrop** is a headless, hooks-first file uploader for React: intake,
+drag/drop, validation, and upload (queue, concurrency, retry, cancel) via
+a single `useMediaDrop` hook — the same `getRootProps`/`getInputProps`
+shape you already know from react-dropzone, with upload built in. No
+prebuilt widget — you own the markup.
 
 `react-mediadrop` ships at **4.4 KB minified + gzipped** (per
 [Bundlephobia](https://bundlephobia.com/package/react-mediadrop)); the
@@ -46,6 +47,14 @@ built-in upload queue react-dropzone doesn't have.
 pnpm add react-mediadrop
 # or: npm install react-mediadrop
 # or: yarn add react-mediadrop
+```
+
+Using an AI coding agent? Also install the Agent Skill so it integrates
+the API correctly on the first try instead of guessing from the package
+name:
+
+```sh
+npx skills add autorender/react-mediadrop
 ```
 
 - Ships as **ESM** with TypeScript types included — works with any modern
@@ -85,6 +94,21 @@ intake/validation state. See the
 [quickstart](https://www.mediadrop.dev/docs/getting-started/quickstart)
 and [upload guide](https://www.mediadrop.dev/docs/guides/upload) for
 the full API.
+
+## Blocks (shadcn registry)
+
+Prebuilt, copy-into-your-project blocks — dropzone, avatar uploader,
+multi-file upload form, S3 direct-upload — installable via the shadcn
+CLI's [GitHub registry](https://ui.shadcn.com/docs/registry/github)
+support, no separate registry server required:
+
+```sh
+npx shadcn@latest add autorender/react-mediadrop/dropzone
+```
+
+Swap `dropzone` for `avatar-uploader`, `multi-file-upload-form`, or
+`s3-direct-upload`. (Shorter `@mediadrop/dropzone` form pending shadcn
+Registry Directory review.)
 
 ## What's implemented
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ name:
 npx skills add autorender/react-mediadrop
 ```
 
+Also indexed on [Context7](https://context7.com/autorender/react-mediadrop)
+— reachable via MCP from Cursor, Claude Code, Windsurf, and other
+Context7-compatible tools with no local install.
+
 - Ships as **ESM** with TypeScript types included — works with any modern
   bundler.
 - Requires **React 18+**.

--- a/apps/docs/docs/getting-started/agent-skill.mdx
+++ b/apps/docs/docs/getting-started/agent-skill.mdx
@@ -48,6 +48,12 @@ docs bug: open an issue on the
 [repo](https://github.com/autorender/react-mediadrop).
 :::
 
+## Context7
+
+This site is also indexed on [Context7](https://context7.com/autorender/react-mediadrop),
+so MCP-enabled tools (Cursor, Claude Code, Windsurf, and others) can pull
+these docs into context without you installing anything.
+
 <CardGroup cols={2}>
   <Card title="Installation" icon="download" href="/getting-started/installation">
     Add the package to your project

--- a/apps/docs/docs/getting-started/agent-skill.mdx
+++ b/apps/docs/docs/getting-started/agent-skill.mdx
@@ -33,6 +33,9 @@ Cursor, Copilot) picks it up automatically.
   cancel contract.
 - **`references/xhr-upload.md`** — the reference transport.
 - **`references/react.md`** — the `useMediaDrop` hook surface.
+- **`references/registry-blocks.md`** — the four prebuilt shadcn-registry
+  blocks (dropzone, avatar uploader, multi-file upload form, S3
+  direct-upload) and when to install one instead of hand-rolling markup.
 - **`references/scope.md`** — what's deliberately not implemented yet,
   so your agent doesn't invent a pause/resume or OAuth API that isn't
   there.

--- a/apps/docs/docs/index.mdx
+++ b/apps/docs/docs/index.mdx
@@ -3,8 +3,11 @@ title: Introduction
 description: A hooks-first, headless file uploader for React
 ---
 
-**react-mediadrop** is a file intake, validation, and upload engine for
-React, published to npm as [`react-mediadrop`](https://www.npmjs.com/package/react-mediadrop).
+**react-mediadrop** is a headless, hooks-first file uploader for React:
+intake, validation, and upload (queue, concurrency, retry, cancel) via a
+single `useMediaDrop` hook — the same `getRootProps`/`getInputProps` shape
+you already know from react-dropzone, with upload built in. Published to
+npm as [`react-mediadrop`](https://www.npmjs.com/package/react-mediadrop).
 
 You can use react-mediadrop for:
 

--- a/skills/mediadrop/SKILL.md
+++ b/skills/mediadrop/SKILL.md
@@ -92,6 +92,8 @@ model, store, and drag-state semantics in detail.
 - Validation/restrictions: [references/validation.md](references/validation.md)
 - Upload (queue/concurrency/retry/cancel, transport contract): [references/upload.md](references/upload.md)
 - Transport: [references/xhr-upload.md](references/xhr-upload.md)
+- Prebuilt blocks (dropzone/avatar-uploader/upload-form/S3, installable via
+  the shadcn CLI): [references/registry-blocks.md](references/registry-blocks.md)
 - Common mistakes: [references/troubleshooting.md](references/troubleshooting.md)
 - Full working demo (dropzone + upload UI + a real backend, wired
   end-to-end) — not shipped with this skill, lives in the source repo:
@@ -100,6 +102,11 @@ model, store, and drag-state semantics in detail.
 
 ## Hard rules for agents integrating mediadrop
 
+- **In a shadcn/ui project, check [references/registry-blocks.md](references/registry-blocks.md)
+  before hand-rolling dropzone/avatar-uploader/upload-form markup** — a
+  matching prebuilt block is one `npx shadcn@latest add
+  autorender/react-mediadrop/<item-name>` away. Skip it only when the
+  task's UI genuinely doesn't fit one of the four blocks.
 - **Do not write upload code that bypasses `transport`/the queue** — no
   hand-rolled `fetch` call stapled onto `onChange`, no ad hoc retry loop
   elsewhere. If the user wants upload behavior, wire a transport

--- a/skills/mediadrop/references/registry-blocks.md
+++ b/skills/mediadrop/references/registry-blocks.md
@@ -1,0 +1,47 @@
+# Prebuilt blocks (shadcn registry)
+
+Four ready-made, copy-into-the-project blocks exist on top of
+`useMediaDrop` — a task asking for a dropzone/avatar-uploader/upload-form
+UI in a project that already uses shadcn/ui does **not** need one
+hand-rolled from scratch; installing the matching block is usually the
+right first move.
+
+| Block | Item name | What it is |
+|---|---|---|
+| Dropzone | `dropzone` | Minimal drag/drop zone, no upload |
+| Avatar uploader | `avatar-uploader` | Circular single-image picker, click/drag replace, upload progress |
+| Multi-file upload form | `multi-file-upload-form` | Multi-file picker + list + per-file progress |
+| S3 direct-upload | `s3-direct-upload` | Presigned-URL direct-to-S3 upload flow |
+
+## Install
+
+```sh
+npx shadcn@latest add autorender/react-mediadrop/<item-name>
+# e.g.
+npx shadcn@latest add autorender/react-mediadrop/dropzone
+```
+
+This is the GitHub-registry address form (`owner/repo/item`) — works
+today, no extra setup on the consumer's side. A shorter
+`@mediadrop/<item-name>` namespace form is pending shadcn Registry
+Directory review; don't assume it works yet.
+
+## Before reaching for a block
+
+- The project must already be a shadcn/ui project (ran `shadcn init`) —
+  every block's className strings use shadcn/ui's theme tokens
+  (`border-input`, `bg-muted`, `text-muted-foreground`,
+  `bg-destructive`, etc.), not raw Tailwind colors. Installing a block
+  into a plain Tailwind project without those CSS variables defined will
+  render, but the theme colors will be wrong/undefined.
+- Each block depends on `react-mediadrop` (added automatically by the
+  CLI) — nothing else. No other shadcn/ui component is a dependency.
+- A block is a starting point copied into the project's own source tree
+  (standard shadcn behavior), not a black-box import — after install,
+  it's just another component the user (or you) can edit directly. Don't
+  treat it as a fixed API surface the way `react-mediadrop` itself is.
+- If the task's UI needs don't match any of the four blocks (custom
+  layout, extra fields, a different transport), build directly on
+  `useMediaDrop` per [react.md](react.md) instead of forcing a block to
+  fit — the blocks are a shortcut for the common cases, not the only
+  supported path.

--- a/skills/mediadrop/references/registry-blocks.md
+++ b/skills/mediadrop/references/registry-blocks.md
@@ -21,10 +21,11 @@ npx shadcn@latest add autorender/react-mediadrop/<item-name>
 npx shadcn@latest add autorender/react-mediadrop/dropzone
 ```
 
-This is the GitHub-registry address form (`owner/repo/item`) — works
-today, no extra setup on the consumer's side. A shorter
-`@mediadrop/<item-name>` namespace form is pending shadcn Registry
-Directory review; don't assume it works yet.
+This is the GitHub-registry address form (`owner/repo/item`) — requires
+an existing shadcn/ui project (ran `shadcn init`), but no additional
+registry setup beyond that. A shorter `@mediadrop/<item-name>` namespace
+form is pending shadcn Registry Directory review; don't assume it works
+yet.
 
 ## Before reaching for a block
 


### PR DESCRIPTION
## Summary

- README + docs Introduction lead with the react-dropzone comparison up front (was buried in README's "Why" section, absent from docs entirely).
- Adds a shadcn GitHub-registry install path (`npx shadcn@latest add autorender/react-mediadrop/dropzone`) for the four registry blocks, documented in README, docs, and the agent skill (`skills/mediadrop/references/registry-blocks.md`). Holds off on the `@mediadrop/dropzone` namespace form until [shadcn-ui/ui#11239](https://github.com/shadcn-ui/ui/pull/11239) merges.
- Surfaces `npx skills add autorender/react-mediadrop` and Context7 indexing next to `npm install` on the README's first screen instead of only on its own docs page.
- Agent skill now points agents at the registry blocks before hand-rolling markup, and states the `shadcn init` prerequisite next to the install-form explanation.

## Test plan

- [x] Diffed all files — prose-only changes, no JSX/component edits
- [ ] Docs site preview build (CF Pages / Blume)