### PR TITLE
ci: enable npm provenance on published release

### DIFF
--- a/.changeset/tame-lions-jump.md
+++ b/.changeset/tame-lions-jump.md
@@ -1,0 +1,5 @@
+---
+"react-mediadrop": patch
+---
+
+No functional change — verifies npm provenance is attached to the published package.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -36,3 +37,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary
- Adds `id-token: write` to the release job so it can request a GitHub Actions OIDC token.
- Sets `NPM_CONFIG_PROVENANCE=true` in the publish step's env, so the underlying `pnpm publish` call (changesets picks `pnpm publish` per the `packageManager` field) attaches a signed build provenance attestation — same mechanism react-email's `scripts/release.mts` uses via `pnpm publish --provenance`, just via env var since we don't have a custom release script.
- No auth changes: `NPM_TOKEN` stays as-is, this only adds the provenance attestation on top of the existing publish flow.

Only verifiable end-to-end on an actual publish (next version bump merge) — npm will then show a "Provenance" panel with a link to the transparency log entry on the package page, like react-email's.

## Test plan
- [ ] Workflow YAML is valid (no local action to dry-run provenance)
- [ ] On next release, confirm npmjs.com package page shows the Provenance panel with a build link back to this repo's release workflow run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package release publishing with enhanced provenance metadata.
  * Updated release workflow permissions to support secure publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->