### PR TITLE
docs: add Website/GitHub nav links to READMEs

### DIFF
--- a/.changeset/nav-links-readme.md
+++ b/.changeset/nav-links-readme.md
@@ -1,0 +1,5 @@
+---
+"react-mediadrop": patch
+---
+
+Add Website/GitHub nav links to the package README.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square)](CODE_OF_CONDUCT.md)
 [![skills.sh](https://skills.sh/b/autorender/react-mediadrop)](https://skills.sh/autorender/react-mediadrop)
 
+<div align="center">
+<a href="https://mediadrop.dev">Website</a>
+<span> · </span>
+<a href="https://github.com/autorender/react-mediadrop">GitHub</a>
+</div>
+
 ## Introduction
 
 **mediadrop** is a headless, hooks-first file uploader for React with zero

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -9,6 +9,12 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square)](../../CODE_OF_CONDUCT.md)
 [![skills.sh](https://skills.sh/b/autorender/react-mediadrop)](https://skills.sh/autorender/react-mediadrop)
 
+<div align="center">
+<a href="https://mediadrop.dev">Website</a>
+<span> · </span>
+<a href="https://github.com/autorender/react-mediadrop">GitHub</a>
+</div>
+
 ## Introduction
 
 **mediadrop** is a headless, hooks-first file uploader for React with zero


### PR DESCRIPTION
## Summary
- Adds a centered Website / GitHub nav row under the badges in both `README.md` and `packages/react/README.md`, mirroring react-email's README header pattern.
- Website links to https://mediadrop.dev, GitHub to this repo.
- Patch changeset included since `packages/react/README.md` ships as the published package's README.

## Test plan
- [ ] Render both READMEs (GitHub preview) to confirm the centered div renders correctly