### PR TITLE
ci: npm provenance + docs: README nav links

### DIFF
--- a/.changeset/nav-links-readme.md
+++ b/.changeset/nav-links-readme.md
@@ -1,0 +1,5 @@
+---
+"react-mediadrop": patch
+---
+
+Add Website/GitHub nav links to the package README.

--- a/.changeset/tame-lions-jump.md
+++ b/.changeset/tame-lions-jump.md
@@ -1,0 +1,5 @@
+---
+"react-mediadrop": patch
+---
+
+No functional change — verifies npm provenance is attached to the published package.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -36,3 +37,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square)](CODE_OF_CONDUCT.md)
 [![skills.sh](https://skills.sh/b/autorender/react-mediadrop)](https://skills.sh/autorender/react-mediadrop)
 
+<div align="center">
+<a href="https://mediadrop.dev">Website</a>
+<span> · </span>
+<a href="https://github.com/autorender/react-mediadrop">GitHub</a>
+</div>
+
 ## Introduction
 
 **mediadrop** is a headless, hooks-first file uploader for React with zero

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -9,6 +9,12 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square)](../../CODE_OF_CONDUCT.md)
 [![skills.sh](https://skills.sh/b/autorender/react-mediadrop)](https://skills.sh/autorender/react-mediadrop)
 
+<div align="center">
+<a href="https://mediadrop.dev">Website</a>
+<span> · </span>
+<a href="https://github.com/autorender/react-mediadrop">GitHub</a>
+</div>
+
 ## Introduction
 
 **mediadrop** is a headless, hooks-first file uploader for React with zero


### PR DESCRIPTION
Combines two small independent changes into one PR.

- Enable npm provenance on published release (`id-token: write` permission, was #29)
- Add Website/GitHub nav links to READMEs (was #30)

Closes #29, closes #30.