### PR TITLE
fix(ci): expose NPM_TOKEN so changesets/action attaches provenance

### DIFF
--- a/.changeset/lazy-otters-verify.md
+++ b/.changeset/lazy-otters-verify.md
@@ -1,0 +1,5 @@
+---
+"react-mediadrop": patch
+---
+
+No functional change — verifies npm provenance attestation is attached after the NPM_TOKEN env fix.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,4 +37,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
0.1.3 published successfully but with no provenance attestation
(confirmed via registry.npmjs.org attestations endpoint → 404).

Root cause: changesets/action writes its own \`.npmrc\` from
\`process.env.NPM_TOKEN\` — a different env var from \`NODE_AUTH_TOKEN\`
that npm CLI/setup-node use. Since only \`NODE_AUTH_TOKEN\` was set,
the action logged "No NPM_TOKEN found, but OIDC is available - using
npm trusted publishing" and used its OIDC fallback path, which
skipped provenance.

Fix: also expose \`NPM_TOKEN\` in the step env so changesets/action
uses the normal token-authenticated publish path, where
\`NPM_CONFIG_PROVENANCE=true\` + \`id-token: write\` attach the
attestation as intended.