### PR TITLE
ci: switch to npm trusted publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.changeset/verify-trusted-publishing.md
+++ b/.changeset/verify-trusted-publishing.md
@@ -1,0 +1,5 @@
+---
+"react-mediadrop": patch
+---
+
+No functional change — verifies npm provenance attestation via trusted publishing (OIDC, no NPM_TOKEN).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
+      - run: npm i -g npm@latest
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
       - name: Create Release PR or publish to npm
@@ -36,6 +37,3 @@ jobs:
           version: pnpm changeset version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
## Summary
- `@changesets/cli` shells to `pnpm publish`, which never passes `--provenance` or reads `NPM_CONFIG_PROVENANCE` — confirmed by two real publishes (v0.1.3, v0.1.4) both landing with zero attestations despite that env var being set.
- npm auto-generates provenance under trusted publishing (OIDC, no token) with zero extra flags — verified against a working reference package.
- Drops `NODE_AUTH_TOKEN`/`NPM_TOKEN`/`NPM_CONFIG_PROVENANCE` from the release workflow, adds explicit `npm i -g npm@latest` (node 22's bundled npm is below the 11.5.1 floor OIDC trusted publishing needs).
- Requires the npm Trusted Publisher entry for `react-mediadrop` (org `autorender`, repo `react-mediadrop`, workflow `release.yml`) — already configured on npm's side.

## Test plan
- [ ] Merge, merge the resulting Version PR
- [ ] Confirm publish succeeds via OIDC (no `NPM_TOKEN` needed)
- [ ] Check `dist.attestations` on the new version via the npm registry API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package release process to use npm trusted publishing with OIDC-based provenance verification.
  * Updated the release workflow to use the latest npm version.
  * No functional or user-facing product changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->