### PR TITLE
docs: add Discord community link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,7 @@ Issue and PR templates (`.github/ISSUE_TEMPLATE/`,
 `.github/PULL_REQUEST_TEMPLATE.md`), a vulnerability-reporting process
 ([`SECURITY.md`](SECURITY.md)), and a [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 already exist. There's no CLA yet.
+
+## Getting help
+
+Questions before or during a PR? Ask in the [Discord](https://discord.gg/5snBtW2aJ) or open a [GitHub issue](https://github.com/autorender/react-mediadrop/issues).

--- a/README.md
+++ b/README.md
@@ -8,11 +8,14 @@
 [![bundle size](https://img.shields.io/badge/min%2Bgzip-4.4KB-success?style=flat-square)](https://bundlephobia.com/package/react-mediadrop)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square)](CODE_OF_CONDUCT.md)
 [![skills.sh](https://skills.sh/b/autorender/react-mediadrop)](https://skills.sh/autorender/react-mediadrop)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/5snBtW2aJ)
 
 <div align="center">
 <a href="https://mediadrop.dev">Website</a>
 <span> · </span>
 <a href="https://github.com/autorender/react-mediadrop">GitHub</a>
+<span> · </span>
+<a href="https://discord.gg/5snBtW2aJ">Discord</a>
 </div>
 
 ## Introduction
@@ -223,7 +226,8 @@ pnpm size    # checks each published/bundled package's gzipped dist against its 
 ## Support
 
 Questions or issues not covered by the [docs](https://www.mediadrop.dev/docs)?
-Open a [GitHub issue](https://github.com/autorender/react-mediadrop/issues) or
+Join the [Discord](https://discord.gg/5snBtW2aJ), open a
+[GitHub issue](https://github.com/autorender/react-mediadrop/issues), or
 email oss@autorender.io.
 
 ## Contributing

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -8,11 +8,14 @@
 [![bundle size](https://img.shields.io/badge/min%2Bgzip-4.4KB-success?style=flat-square)](https://bundlephobia.com/package/react-mediadrop)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square)](../../CODE_OF_CONDUCT.md)
 [![skills.sh](https://skills.sh/b/autorender/react-mediadrop)](https://skills.sh/autorender/react-mediadrop)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/5snBtW2aJ)
 
 <div align="center">
 <a href="https://mediadrop.dev">Website</a>
 <span> · </span>
 <a href="https://github.com/autorender/react-mediadrop">GitHub</a>
+<span> · </span>
+<a href="https://discord.gg/5snBtW2aJ">Discord</a>
 </div>
 
 ## Introduction
@@ -223,7 +226,8 @@ pnpm size    # checks each published/bundled package's gzipped dist against its 
 ## Support
 
 Questions or issues not covered by the [docs](https://www.mediadrop.dev/docs)?
-Open a [GitHub issue](https://github.com/autorender/react-mediadrop/issues) or
+Join the [Discord](https://discord.gg/5snBtW2aJ), open a
+[GitHub issue](https://github.com/autorender/react-mediadrop/issues), or
 email oss@autorender.io.
 
 ## Contributing


### PR DESCRIPTION
## Summary

Adds the Autorender Discord invite (https://discord.gg/5snBtW2aJ) to react-mediadrop's community/support surfaces:

- Root `README.md` and `packages/react/README.md`: badge, header nav link, and Support section mention.
- `CONTRIBUTING.md`: new "Getting help" section.

Docs-only, no changeset needed.

## Test plan

- [x] Rendered both READMEs locally to confirm markdown/badge formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Discord as a support channel in contributor guidelines and documentation
  * Updated support instructions to direct users to Discord for assistance with questions and issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->