### PR TITLE
chore: add changeset for Discord README link

### DIFF
--- a/.changeset/add-discord-link.md
+++ b/.changeset/add-discord-link.md
@@ -1,0 +1,5 @@
+---
+"react-mediadrop": patch
+---
+
+Add Discord community link to the README.


### PR DESCRIPTION
Adds a patch changeset for `react-mediadrop` so the next release republishes with the Discord link already merged into the README (npm's rendered README only updates on a version bump).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Discord community link to the README.
* **Chores**
  * Prepared a patch release containing the documentation update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->