### PR TITLE
chore: force LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Biome formats with LF, so a checkout that converts to CRLF (the Git for
+# Windows default, core.autocrlf=true) makes `pnpm lint` fail on every file.
+# `text=auto` still leaves real binaries like assets/*.png alone.
+* text=auto eol=lf


### PR DESCRIPTION
## Summary

- Adds `.gitattributes` with `* text=auto eol=lf` so checkouts are LF on every platform.
- Biome formats with LF. On Windows, Git's default `core.autocrlf=true` converts to CRLF on
  checkout, so `pnpm lint` reports 128 errors across 133 files on an otherwise untouched
  clone — every one of them a `␍` diff. CI is ubuntu-only, so this never surfaces there.
- No file contents change: the index already holds LF for every file (0 CRLF blobs), so this
  affects checkout behavior only and needs no renormalization commit.

## Related issue

None.

## Test plan

- [x] `pnpm changeset` — not needed (internal/tooling change)
- [x] `pnpm lint` passes (was 128 errors before this change)
- [ ] `pnpm typecheck` — could not run locally, see note
- [x] `pnpm test` — `@mediadrop/core` passes (123 tests); see note
- [ ] `pnpm build` — could not run locally, see note
- [ ] `pnpm size` — could not run locally, see note

Note: on Node < 22.18 `tsdown` fails to load its `.ts` config (`Failed to import module
"unrun"`), which blocks `build` and therefore `typecheck`/`test` via the turbo pipeline.

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized text files to use LF line endings.
  * Preserved binary file handling and improved cross-platform formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->