### PR TITLE
chore: align Node requirement with tsdown and .node-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version-file: .node-version
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm lint
@@ -37,7 +37,7 @@ jobs:
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version-file: .node-version
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm typecheck
@@ -50,7 +50,7 @@ jobs:
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version-file: .node-version
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test -- --coverage
@@ -63,7 +63,7 @@ jobs:
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version-file: .node-version
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version-file: .node-version
           cache: pnpm
           registry-url: https://registry.npmjs.org
       - run: npm i -g npm@latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 Thanks for your interest in contributing to `react-mediadrop`. The short version:
 
+**Prerequisites:** Node matching [`.node-version`](.node-version). `tsdown` loads its `.ts` config via Node's native TypeScript support; on older Node it falls back to `unrun`, an optional peer dependency that isn't installed, and the build fails with `Failed to import module "unrun"`.
+
 1. **Install & verify**: `pnpm install`, then `pnpm lint && pnpm typecheck && pnpm test && pnpm build && pnpm size` before opening a PR — this is exactly what CI runs (`.github/workflows/ci.yml`).
 2. **Scope**: check
    [`skills/mediadrop/references/scope.md`](skills/mediadrop/references/scope.md)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
 	"type": "module",
 	"packageManager": "pnpm@11.10.0",
 	"engines": {
-		"node": ">=20"
+		"node": "^22.18.0 || >=24.11.0"
 	},
 	"scripts": {
 		"build": "turbo run build",


### PR DESCRIPTION
package.json claimed engines.node >=20, but tsdown loads its .ts config via Node native TypeScript (22.18+ / 24.11+) or falls back to unrun, an optional peer pnpm never installs. On Node 22.17 that fails with Failed to import module unrun, blocking build/test/typecheck.

Set engines to ^22.18.0 || >=24.11.0, point CI and release workflows at .node-version (24.11.0), and document the prerequisite in CONTRIBUTING.

## Summary

<!-- What changed and why, in 1-3 bullet points. -->

## Related issue

<!-- Closes #... , or "None" -->

## Test plan

- [ ] `pnpm changeset` added (or not needed — docs-only/internal change)
- [ ] `pnpm lint` passes
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes (new tests added for new behavior, if applicable)
- [ ] `pnpm build` passes
- [ ] `pnpm size` passes (bundle size budgets unaffected, or budget change explained above)

## Breaking changes

<!-- None, or describe what consumers need to change. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added prerequisites guidance covering the required Node.js versions and compatibility with project tooling.

* **Chores**
  * Updated the minimum supported Node.js version.
  * CI and release workflows now automatically use the version specified by the repository configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->