### PR TITLE
fix: update Discord invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,4 +48,4 @@ already exist. There's no CLA yet.
 
 ## Getting help
 
-Questions before or during a PR? Ask in the [Discord](https://discord.gg/5snBtW2aJ) or open a [GitHub issue](https://github.com/autorender/react-mediadrop/issues).
+Questions before or during a PR? Ask in the [Discord](https://discord.gg/cZuSUaAwAy) or open a [GitHub issue](https://github.com/autorender/react-mediadrop/issues).

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@
 [![bundle size](https://img.shields.io/badge/min%2Bgzip-4.4KB-success?style=flat-square)](https://bundlephobia.com/package/react-mediadrop)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square)](CODE_OF_CONDUCT.md)
 [![skills.sh](https://skills.sh/b/autorender/react-mediadrop)](https://skills.sh/autorender/react-mediadrop)
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/5snBtW2aJ)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/cZuSUaAwAy)
 
 <div align="center">
 <a href="https://mediadrop.dev">Website</a>
 <span> · </span>
 <a href="https://github.com/autorender/react-mediadrop">GitHub</a>
 <span> · </span>
-<a href="https://discord.gg/5snBtW2aJ">Discord</a>
+<a href="https://discord.gg/cZuSUaAwAy">Discord</a>
 </div>
 
 ## Introduction
@@ -226,7 +226,7 @@ pnpm size    # checks each published/bundled package's gzipped dist against its 
 ## Support
 
 Questions or issues not covered by the [docs](https://www.mediadrop.dev/docs)?
-Join the [Discord](https://discord.gg/5snBtW2aJ), open a
+Join the [Discord](https://discord.gg/cZuSUaAwAy), open a
 [GitHub issue](https://github.com/autorender/react-mediadrop/issues), or
 email oss@autorender.io.
 

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -8,14 +8,14 @@
 [![bundle size](https://img.shields.io/badge/min%2Bgzip-4.4KB-success?style=flat-square)](https://bundlephobia.com/package/react-mediadrop)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=flat-square)](../../CODE_OF_CONDUCT.md)
 [![skills.sh](https://skills.sh/b/autorender/react-mediadrop)](https://skills.sh/autorender/react-mediadrop)
-[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/5snBtW2aJ)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat-square&logo=discord&logoColor=white)](https://discord.gg/cZuSUaAwAy)
 
 <div align="center">
 <a href="https://mediadrop.dev">Website</a>
 <span> · </span>
 <a href="https://github.com/autorender/react-mediadrop">GitHub</a>
 <span> · </span>
-<a href="https://discord.gg/5snBtW2aJ">Discord</a>
+<a href="https://discord.gg/cZuSUaAwAy">Discord</a>
 </div>
 
 ## Introduction
@@ -226,7 +226,7 @@ pnpm size    # checks each published/bundled package's gzipped dist against its 
 ## Support
 
 Questions or issues not covered by the [docs](https://www.mediadrop.dev/docs)?
-Join the [Discord](https://discord.gg/5snBtW2aJ), open a
+Join the [Discord](https://discord.gg/cZuSUaAwAy), open a
 [GitHub issue](https://github.com/autorender/react-mediadrop/issues), or
 email oss@autorender.io.
 


### PR DESCRIPTION
## Summary
- Old Discord invite (discord.gg/5snBtW2aJ) expired, replaced with new invite across README.md, CONTRIBUTING.md, packages/react/README.md

## Test plan
- [x] Grepped repo for remaining old invite references, none found

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Discord invite links across the main and React package documentation.
  * Ensured help, support, badges, and navigation links point to the current community invite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->